### PR TITLE
Add ability to run fiber coroutines in a script command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ set(BINDING_SOURCE
 	binding-mri/chroma-binding.cpp
 	binding-mri/niko-binding.cpp
 	binding-mri/modshot-window-binding.cpp
+	binding-mri/modshot-fiber-binding.cpp
 )
 
 source_group("Binding Source" FILES ${BINDING_SOURCE} ${BINDING_HEADERS})

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -84,6 +84,7 @@ void oneshotBindingInit();
 void steamBindingInit();
 void chromaBindingInit();
 void modshotwindowBindingInit();
+void modshotFiberBindingInit();
 RB_METHOD(mriPrint);
 RB_METHOD(mriP);
 RB_METHOD(mkxpDataDirectory);
@@ -120,6 +121,7 @@ static void mriBindingInit()
 	steamBindingInit();
 	chromaBindingInit();
 	modshotwindowBindingInit();
+	modshotFiberBindingInit();
 	if (rgssVer >= 3)
 	{
 		_rb_define_module_function(rb_mKernel, "rgss_main", mriRgssMain);

--- a/binding-mri/modshot-fiber-binding.cpp
+++ b/binding-mri/modshot-fiber-binding.cpp
@@ -1,0 +1,10 @@
+#include "binding-util.h"
+
+RB_METHOD(modshot_rb_fiber_alive_p) {
+    return rb_fiber_alive_p(self);
+}
+
+void modshotFiberBindingInit() {
+    VALUE rb_cFiber = rb_define_class("Fiber", rb_cObject);
+    _rb_define_method(rb_cFiber, "alive?", modshot_rb_fiber_alive_p);
+}

--- a/scripts/Interpreter_1.rb
+++ b/scripts/Interpreter_1.rb
@@ -37,6 +37,7 @@ class Interpreter
     @child_interpreter = nil          # child interpreter
     @branch = {}                      # branch data
     @event_name = nil                 # full event name
+    @fiber = nil                      # current fiber if running a coroutine
   end
   #--------------------------------------------------------------------------
   # * Event Setup
@@ -135,6 +136,15 @@ class Interpreter
       if @@chill_pill
         @@chill_pill = false
         return
+      end
+      # Fiber processing
+      if @fiber != nil
+        @fiber.resume
+        if @fiber.alive?
+          return
+        end
+        @fiber = nil
+        @index += 1
       end
       # If map is different than event startup time
       if $game_map.map_id != @map_id

--- a/scripts/Interpreter_7.rb
+++ b/scripts/Interpreter_7.rb
@@ -276,7 +276,14 @@ class Interpreter
     #  return false
     #end
     # Continue
-    eval(script)
+    result = eval(script)
+    if result.is_a?(Fiber)
+      result.resume
+      if result.alive?
+        @fiber = result
+        return false
+      end
+    end
     return true
   end
 end


### PR DESCRIPTION
With this change, you should be able to invoke fibers as coroutines inside an event. If you have a `Script` command inside an event page and it evaluates to a fiber, that fiber will be executed to completion before your event page continues running. For now, if the fiber yields, it will resume execution in the next frame. We can add more features like "yield until timeout" or "yield until I/O operation complete" if you want.

Example:
`Bouncer.rb` (inside `xScripts.rxdata`):
```ruby
def getWindowPos
    result = ModWindow.GetWindowPosition()
    @x = result[0]
    @y = result[1]
end
def createBounceFiber(length, acceleration)
    return Fiber.new do
        velocity = 0
        while velocity < length
            getWindowPos
            @y += velocity
            velocity += acceleration
            ModWindow.SetWindowPosition(@x, @y)
            Fiber.yield
        end
        while velocity > 0
            getWindowPos
            @y += velocity
            velocity -= acceleration
            ModWindow.SetWindowPosition(@x, @y)
            Fiber.yield
        end
        while velocity > -length
            getWindowPos
            @y += velocity
            velocity -= acceleration
            ModWindow.SetWindowPosition(@x, @y)
            Fiber.yield
        end
        while velocity < 0
            getWindowPos
            @y += velocity
            velocity += acceleration
            ModWindow.SetWindowPosition(@x, @y)
            Fiber.yield
        end
    end
end
```
Some random parallel processing event:
```
Text: Before fiber
Script: "createBounceFiber(5, 0.25)"
Text: After fiber
```

Since `createBounceFiber` returned a fiber, it will finish executing before "After fiber" is displayed. Each time `Fiber.yield` is called, the coroutine gives up execution and will resume from there on the next frame. All other events / graphics updates / etc can proceed as normal in the meantime.

(You probably have to merge the changes in the interpreter manually into OSFM-Github, but at least git gives you a diff to show what I changed)