### PR TITLE
Build ModShot for Windows using GitHub workflows

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -1,0 +1,18 @@
+name: build-windows
+on: push
+jobs:
+  build-windows:
+    name: Build ModShot for Windows
+    runs-on: windows-2019
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Pull down build container
+        run: docker pull rkevin/build-oneshot-windows
+      - name: Build ModShot
+        run: mkdir "${{ runner.temp }}\dist"; docker run --rm -v "${{ github.workspace }}:C:\work\src" -v "${{ runner.temp }}\dist:C:\work\dist" --entrypoint cmd rkevin/build-oneshot-windows:latest "/C" "mkdir C:\work\build && cd \work\build && conan install \work\src --build=missing && conan build \work\src && xcopy C:\work\build\bin C:\work\dist /E /H || echo Modshot build success."
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modshot_build_windows_${{ github.sha }}
+          path: ${{ runner.temp }}\dist


### PR DESCRIPTION
This workflow will autocompile ModShot for Windows whenever there is a push to any branch, and you can download the compiled binaries as an artifact. Each build takes around 35 minutes, so it's not ideal, but for those who don't want to mess with Docker this is a valid alternative. Free GitHub users get 2000 minutes per month of GitHub Actions, and Windows has a 2x multiplier on time (so it bills ~70 minutes per compilation). This should let the average person compile ModShot 28 times in a month, assuming they don't use GitHub actions elsewhere. I'll look into not using a Docker container and somehow making conan work directly, but I'm not sure if it'll be faster without caching the conan build cache.