### PR TITLE
Fix CRLF issues when building linux appimage on windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -63,6 +63,15 @@ class MkxpConan(ConanFile):
             self.options["sdl2"].shared = True
 
     def build_configure(self):
+        # if we are on windows, git might clone files using the CRLF newline
+        # this will cause issues when building for linux, as some scripts cannot run properly
+        # we run dos2unix on them to convert their line endings
+        for file in ['make-appimage.sh', 'assets/AppRun', 'assets/oneshot.desktop']:
+            try:
+                tools.dos2unix(os.path.join(self.source_folder, file))
+            except FileNotFoundError:
+                pass # in case windows users don't need those files
+
         cmake = CMake(self, msbuild_verbosity='minimal')
         if self.options.platform == "steam":
             cmake.definitions["STEAM"] = "ON"


### PR DESCRIPTION
If you cloned this repo on windows and then build for linux, git would have cloned all the text files with CRLF line endings, and linux doesn't like that. This PR will let conan run dos2unix on several Linux-only files every time it builds, so this issue can be caught early on. Tested on a linux system and it should work.