### PR TITLE
Add baremetal build workflow

### DIFF
--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,9 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim;
+        run: choco install -y conan vim
       - name: Set path to include xxd
-        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+        run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan
         run: |
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim
+        run: choco install -y vim; pip install conan
       - name: Set path to include xxd
         run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -5,14 +5,13 @@ jobs:
     name: Build ModShot for Windows without Docker containers
     runs-on: windows-2019
     env:
-      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
-      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+      CONAN_USER_HOME: C:\.conan
+      CONAN_USER_HOME_SHORT: C:\.conan
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install and setup conan
         run: |
-          mkdir ${{ runner.temp }}\conan;
           mkdir ${{ runner.temp }}\build;
           choco install -y conan vim;
           [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
@@ -22,7 +21,7 @@ jobs:
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:
-          path: env.CONAN_USER_HOME
+          path: C:\.conan
           key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
       - name: Build dependencies using conan
         run: conan install ${{ github.workspace }} --build=missing

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -10,14 +10,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install and setup conan
+      - name: Install conan and xxd
+        run: choco install -y conan vim;
+      - name: Set path to include xxd
+        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+      - name: Configure conan
         run: |
-          mkdir ${{ runner.temp }}\build;
-          choco install -y conan vim;
-          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;
           conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
-          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1;
+          mkdir ${{ runner.temp }}\build
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -1,0 +1,37 @@
+name: build-windows-baremetal
+on: push
+jobs:
+  build-windows:
+    name: Build ModShot for Windows without Docker containers
+    runs-on: windows-2019
+    env:
+      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
+      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install and setup conan
+        run: |
+          mkdir ${{ runner.temp }}\conan;
+          mkdir ${{ runner.temp }}\build;
+          choco install -y conan vim;
+          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
+          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
+          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+      - name: Cache conan dependencies
+        uses: actions/cache@v2
+        with:
+          path: env.CONAN_USER_HOME
+          key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
+      - name: Build dependencies using conan
+        run: conan install ${{ github.workspace }} --build=missing
+        working-directory: ${{ runner.temp }}\build
+      - name: Build ModShot
+        run: conan build ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}\build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modshot_build_windows_latest
+          path: ${{ runner.temp }}\build\bin


### PR DESCRIPTION
This was done a long time ago, I just forgot to make a PR for it. This build action does not rely on the docker image, so it's more flexible when you change the conanfile dependencies. Its cache is also quicker than the docker image. The first build will be slower, but it's still nice to have (plus since this is a public repo, github actions are basically free so there's no downside to having two windows builds)

Also, a linux build workflow is coming, although I don't have an ETA for it.