### PR TITLE
HTTPs support (and Ruby library support in general)

### DIFF
--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,9 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim;
+        run: choco install -y conan vim
       - name: Set path to include xxd
-        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+        run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan
         run: |
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim
+        run: choco install -y vim; pip install conan
       - name: Set path to include xxd
         run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -5,14 +5,13 @@ jobs:
     name: Build ModShot for Windows without Docker containers
     runs-on: windows-2019
     env:
-      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
-      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+      CONAN_USER_HOME: C:\.conan
+      CONAN_USER_HOME_SHORT: C:\.conan
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install and setup conan
         run: |
-          mkdir ${{ runner.temp }}\conan;
           mkdir ${{ runner.temp }}\build;
           choco install -y conan vim;
           [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
@@ -22,7 +21,7 @@ jobs:
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:
-          path: env.CONAN_USER_HOME
+          path: C:\.conan
           key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
       - name: Build dependencies using conan
         run: conan install ${{ github.workspace }} --build=missing

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -10,14 +10,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install and setup conan
+      - name: Install conan and xxd
+        run: choco install -y conan vim;
+      - name: Set path to include xxd
+        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+      - name: Configure conan
         run: |
-          mkdir ${{ runner.temp }}\build;
-          choco install -y conan vim;
-          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;
           conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
-          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1;
+          mkdir ${{ runner.temp }}\build
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -1,0 +1,37 @@
+name: build-windows-baremetal
+on: push
+jobs:
+  build-windows:
+    name: Build ModShot for Windows without Docker containers
+    runs-on: windows-2019
+    env:
+      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
+      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install and setup conan
+        run: |
+          mkdir ${{ runner.temp }}\conan;
+          mkdir ${{ runner.temp }}\build;
+          choco install -y conan vim;
+          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
+          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
+          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+      - name: Cache conan dependencies
+        uses: actions/cache@v2
+        with:
+          path: env.CONAN_USER_HOME
+          key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
+      - name: Build dependencies using conan
+        run: conan install ${{ github.workspace }} --build=missing
+        working-directory: ${{ runner.temp }}\build
+      - name: Build ModShot
+        run: conan build ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}\build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modshot_build_windows_latest
+          path: ${{ runner.temp }}\build\bin

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -159,6 +159,10 @@ static void mriBindingInit()
 		rb_gv_set("TEST", debug);
 
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
+
+	// set environment variable for openssl to detect our cert bundle
+	// the 0 means it won't overwrite the variable if the user wants to set one
+	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -168,7 +168,7 @@ static void mriBindingInit()
 #ifdef _WIN32
 	char tmpbuf[2];
 	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
-		SetEnvironmentVariableA("SSL_CERT_FILE", ".\ssl\cacert.pem");
+		SetEnvironmentVariableA("SSL_CERT_FILE", ".\\ssl\\cacert.pem");
 	}
 #else
 	// the 0 means it won't overwrite the variable if the user wants to set one

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -41,6 +41,10 @@
 
 #include <SDL_filesystem.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 extern const char module_rpg1[];
 
 static void mriBindingExecute();
@@ -161,8 +165,15 @@ static void mriBindingInit()
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
 
 	// set environment variable for openssl to detect our cert bundle
+#ifdef _WIN32
+	char tmpbuf[2];
+	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
+		SetEnvironmentVariableA("SSL_CERT_FILE", ".\ssl\cacert.pem");
+	}
+#else
 	// the 0 means it won't overwrite the variable if the user wants to set one
 	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
+#endif
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -98,6 +98,12 @@ RB_METHOD(_kernelCaller);
 
 static void mriBindingInit()
 {
+	// setup ruby library paths
+	rb_eval_string(
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
+	);
+
 	tableBindingInit();
 	etcBindingInit();
 	fontBindingInit();

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -41,10 +41,6 @@
 
 #include <SDL_filesystem.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 extern const char module_rpg1[];
 
 static void mriBindingExecute();
@@ -165,15 +161,12 @@ static void mriBindingInit()
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
 
 	// set environment variable for openssl to detect our cert bundle
-#ifdef _WIN32
-	char tmpbuf[2];
-	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
-		SetEnvironmentVariableA("SSL_CERT_FILE", ".\\ssl\\cacert.pem");
-	}
-#else
-	// the 0 means it won't overwrite the variable if the user wants to set one
-	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
-#endif
+
+	rb_eval_string(
+		"if ENV['SSL_CERT_FILE'].nil?\n"
+		"    ENV['SSL_CERT_FILE'] = './ssl/cacert.pem'\n"
+		"end\n"
+	);
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -98,12 +98,6 @@ RB_METHOD(_kernelCaller);
 
 static void mriBindingInit()
 {
-	// setup ruby library paths
-	rb_eval_string(
-		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
-		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
-	);
-
 	tableBindingInit();
 	etcBindingInit();
 	fontBindingInit();
@@ -595,6 +589,22 @@ static void mriBindingExecute()
 	ruby_sysinit(&argc, &argv);
 
 	ruby_setup();
+
+	// setup ruby library paths
+	rb_eval_string(
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
+	);
+
+	// we probably should only be calling this if we are a ruby executable
+        // but we need to initialize things like the prelude (provides important library functions like IO#read_nonblock
+        // Init_prelude is not exposed anywhere else
+
+        // the three arguments are the executable name, and the '-e ""' is to tell ruby to run an empty file
+        // otherwise (since this parses options for the ruby executable) it's gonna wait on stdin for code
+        char* options_argv[] = {"oneshot", "-e", "", NULL};
+	ruby_options(3, options_argv);
+
 	rb_enc_set_default_external(rb_enc_from_encoding(rb_utf8_encoding()));
 
 	Config &conf = shState->rtData().config;

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,6 +38,7 @@ class MkxpConan(ConanFile):
         "cygwin_installer:packages=xxd",
         # Avoid dead url bitrot in cygwin_installer
         "cygwin_installer:with_pear=False",
+        "ruby:with_openssl=True",
     )
 
     #def build_requirements(self):
@@ -108,3 +109,11 @@ class MkxpConan(ConanFile):
                  keep_path=True)
             if self.settings.build_type == "Debug":
                 copy("*.pdb", dst="bin", root_package=dep, keep_path=False)
+        # copy the ruby standard library
+	# this is a very ugly way of doing this (putting it in bin instead of lib)
+	# but this makes distributing mods easier, and also makes sure windows and linux are mostly the same
+        copy("*",
+            dst="bin/lib/ruby/",
+            src="lib/ruby/2.5.0/",
+            root_package="ruby",
+            keep_path=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,6 +92,10 @@ class MkxpConan(ConanFile):
         #    self.build_configure()
         self.build_configure()
 
+        # ship certificates into the ssl folder in the game directory
+        # openssl will use this folder since we hardcoded it in binding-mri.cpp
+        tools.download("https://curl.haxx.se/ca/cacert.pem", "bin/ssl/cacert.pem", overwrite=True)
+
     def package(self):
         self.copy("*", dst="bin", src="bin")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,6 +64,15 @@ class MkxpConan(ConanFile):
             self.options["sdl2"].shared = True
 
     def build_configure(self):
+        # if we are on windows, git might clone files using the CRLF newline
+        # this will cause issues when building for linux, as some scripts cannot run properly
+        # we run dos2unix on them to convert their line endings
+        for file in ['make-appimage.sh', 'assets/AppRun', 'assets/oneshot.desktop']:
+            try:
+                tools.dos2unix(os.path.join(self.source_folder, file))
+            except FileNotFoundError:
+                pass # in case windows users don't need those files
+
         cmake = CMake(self, msbuild_verbosity='minimal')
         if self.options.platform == "steam":
             cmake.definitions["STEAM"] = "ON"

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -45,8 +45,9 @@ $LINUXDEPLOY -e "$conan_install_path/bin/oneshot" \
 	     --custom-apprun="$source_path/assets/AppRun" \
 	     --appdir "$appdir"
 
-# Copy ruby standard library
+# Copy ruby standard library and ssl cert bundle
 cp -af "$conan_install_path/bin/lib/" "$appdir/usr/bin/lib"
+cp -af "$conan_install_path/bin/ssl/" "$appdir/usr/bin/ssl"
 
 # Bundle game data
 cp -af "$journal_file" "$appdir/usr/bin/_______"

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -45,6 +45,9 @@ $LINUXDEPLOY -e "$conan_install_path/bin/oneshot" \
 	     --custom-apprun="$source_path/assets/AppRun" \
 	     --appdir "$appdir"
 
+# Copy ruby standard library
+cp -af "$conan_install_path/bin/lib/" "$appdir/usr/bin/lib"
+
 # Bundle game data
 cp -af "$journal_file" "$appdir/usr/bin/_______"
 cp -af "$source_path/assets/journal.png" "$appdir/usr/bin/_______.png"


### PR DESCRIPTION
At long last! This PR adds Ruby library support to ModShot. ModShot will now ship ruby standard libraries with it, and you should be able to use it in your code anywhere. This should allow the use of arbitrary ruby gems too, but I don't have a way to automatically build them yet (you can manually place them into `lib/ruby` after building I suppose)

This also ships the default Mozilla certificate store with ModShot, so OpenSSL can work. The `net/http` library should work without any issues in RGSS code, just `require 'net/http'`.

Detailed changes:
- Build Eliza's ruby with `with-openssl=True` to enable the openssl extension ([conanfile.py](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-63f09721ade419d29886e8190ffa3c9c756baa9bef8802a7f2aeabf3b545164fR41))
- Copy the built libraries and extensions to the ModShot dist folder under `lib/ruby` ([conanfile.py](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-63f09721ade419d29886e8190ffa3c9c756baa9bef8802a7f2aeabf3b545164fR125-R132) and [make-appimage.sh](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-1e0efc5f97f2da988ae1945841f6d21eb26526b73b89867040d1f3e3bbfe0757R49))
- Automatically download the Mozilla CA store from [curl](https://curl.se/docs/caextract.html) and put it in `ssl/cacert.pem` in the dist folder ([conanfile.py](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-63f09721ade419d29886e8190ffa3c9c756baa9bef8802a7f2aeabf3b545164fR95-R98) and [make-appimage.sh](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-1e0efc5f97f2da988ae1945841f6d21eb26526b73b89867040d1f3e3bbfe0757R50)
- Add `lib/ruby` into our ruby library search path early on in the ruby initialization process ([binding-mri.cpp](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-b9f64a65b201ac21b2a1cf961f86045e59a9616dfdc2bdff3bf2233840955af6R602-R605))
- Initialize ruby properly using `ruby_options`, which should evaluate the prelude (contains important stuff like IO#read_nonblock) and some encoding stuff (so no need to require `enc/encdb` and stuff) ([binding-mri.cpp](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-b9f64a65b201ac21b2a1cf961f86045e59a9616dfdc2bdff3bf2233840955af6R613-R614))
- Add the `SSL_CERT_FILE` environment variable to point it to our shipped certificate store ([binding-mri.cpp](https://github.com/Astrabit-ST/Modshot-Core/compare/master...rkevin-arch:http-support-attempt-3?expand=1#diff-b9f64a65b201ac21b2a1cf961f86045e59a9616dfdc2bdff3bf2233840955af6R162-R169))

A test build is available [here](https://github.com/rkevin-arch/Modshot-Core/actions/runs/540764073) for windows, and you can test it by running `$game_temp.message_text = Net::HTTP.get(URI('http://example.com'))[0..62]` in an event somewhere (should output the first lines of HTML in a in-game textbox.