### PR TITLE
Update Docker build setup

### DIFF
--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,9 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim;
+        run: choco install -y conan vim
       - name: Set path to include xxd
-        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+        run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan
         run: |
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install conan and xxd
-        run: choco install -y conan vim
+        run: choco install -y vim; pip install conan
       - name: Set path to include xxd
         run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -2,7 +2,7 @@ name: build-windows-baremetal
 on: push
 jobs:
   build-windows:
-    name: Build ModShot for Windows without Docker containers
+    name: Build ModShot for Windows
     runs-on: windows-2019
     env:
       CONAN_USER_HOME: C:\.conan
@@ -34,5 +34,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: modshot_build_windows_latest
+          name: modshot_build_windows_${{ github.sha }}
           path: ${{ runner.temp }}\build\bin

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -5,14 +5,13 @@ jobs:
     name: Build ModShot for Windows without Docker containers
     runs-on: windows-2019
     env:
-      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
-      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+      CONAN_USER_HOME: C:\.conan
+      CONAN_USER_HOME_SHORT: C:\.conan
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install and setup conan
         run: |
-          mkdir ${{ runner.temp }}\conan;
           mkdir ${{ runner.temp }}\build;
           choco install -y conan vim;
           [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
@@ -22,7 +21,7 @@ jobs:
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:
-          path: env.CONAN_USER_HOME
+          path: C:\.conan
           key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
       - name: Build dependencies using conan
         run: conan install ${{ github.workspace }} --build=missing

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -10,14 +10,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install and setup conan
+      - name: Install conan and xxd
+        run: choco install -y conan vim;
+      - name: Set path to include xxd
+        run: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine')
+      - name: Configure conan
         run: |
-          mkdir ${{ runner.temp }}\build;
-          choco install -y conan vim;
-          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
           conan remote add eliza https://api.bintray.com/conan/eliza/conan;
           conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
-          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1;
+          mkdir ${{ runner.temp }}\build
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-windows-baremetal.yaml
+++ b/.github/workflows/build-windows-baremetal.yaml
@@ -1,0 +1,37 @@
+name: build-windows-baremetal
+on: push
+jobs:
+  build-windows:
+    name: Build ModShot for Windows without Docker containers
+    runs-on: windows-2019
+    env:
+      CONAN_USER_HOME: "${{ runner.temp }}\\conan"
+      CONAN_USER_HOME_SHORT: "${{ runner.temp }}\\conan\\short"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install and setup conan
+        run: |
+          mkdir ${{ runner.temp }}\conan;
+          mkdir ${{ runner.temp }}\build;
+          choco install -y conan vim;
+          [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\tools\vim\vim82', 'Machine');
+          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
+          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          setx CONAN_USE_ALWAYS_SHORT_PATHS 1
+      - name: Cache conan dependencies
+        uses: actions/cache@v2
+        with:
+          path: env.CONAN_USER_HOME
+          key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
+      - name: Build dependencies using conan
+        run: conan install ${{ github.workspace }} --build=missing
+        working-directory: ${{ runner.temp }}\build
+      - name: Build ModShot
+        run: conan build ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}\build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modshot_build_windows_latest
+          path: ${{ runner.temp }}\build\bin

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -2,13 +2,13 @@ name: build-windows
 on: push
 jobs:
   build-windows:
-    name: Build ModShot for Windows
+    name: Build ModShot for Windows with Docker
     runs-on: windows-2019
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Pull down build container
-        run: docker pull rkevin/build-oneshot-windows
+        run: docker pull rkevin/build-oneshot-windows:with-openssl
       - name: Build ModShot
         run: mkdir "${{ runner.temp }}\dist"; docker run --rm -v "${{ github.workspace }}:C:\work\src" -v "${{ runner.temp }}\dist:C:\work\dist" --entrypoint cmd rkevin/build-oneshot-windows:latest "/C" "mkdir C:\work\build && cd \work\build && conan install \work\src --build=missing && conan build \work\src && xcopy C:\work\build\bin C:\work\dist /E /H || echo Modshot build success."
       - name: Upload artifact

--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -6,16 +6,9 @@ conan remote add bincrafters "https://api.bintray.com/conan/bincrafters/public-c
 RUN sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y xorg-dev libx11-xcb-dev libxcb-render0-dev libxcb-render-util0-dev libgtk2.0-dev libxfconf-0-dev vim libwmf0.2-7-gtk librsvg2-common rsync
 RUN sudo python -m pip install mako pyqt5 pyinstaller
 
-RUN conan install boost/1.73.0@_/_ --build=missing -o boost:without_test=True
-RUN conan install openal/1.18.2@bincrafters/stable --build=missing
-RUN conan install physfs/3.0.1@bincrafters/stable --build=missing
-RUN conan install pixman/0.34.0@bincrafters/stable --build=missing
-RUN conan install ruby/2.5.3@eliza/testing --build=missing
-RUN conan install sdl2/2.0.9@bincrafters/stable --build=missing
-RUN conan install sdl2_image/2.0.5@bincrafters/stable --build=missing
-RUN conan install sdl2_ttf/2.0.15@bincrafters/stable --build=missing
-RUN conan install sdl_sound-mkxp/1.0.1@eliza/stable --build=missing
-RUN conan install sigc++/2.10.0@bincrafters/stable --build=missing
+# install all dependencies for the conanfile in commit
+COPY --chown=conan:root conanfile.py /tmp/install_deps/conanfile.py
+RUN conan install --build=missing /tmp/install_deps && sudo rm -r /tmp/install_deps
 
 ADD https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage /tmp
 # can't find a stable release for linuxdeploy, oh well

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -3,60 +3,24 @@
 
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 
-# install vs buildtools
-ADD https://aka.ms/vs/16/release/vs_buildtools.exe /vs_buildtools.exe
-RUN C:\vs_buildtools.exe --quiet --wait --norestart --nocache `
---installPath C:\BuildTools `
---add Microsoft.VisualStudio.Workload.VCTools `
---remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
---remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
---remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
---remove Microsoft.VisualStudio.Component.Windows81SDK `
---includeRecommended
+# install vs community (not vs buildtools because we need devenv to upgrade vs solutions
+ADD https://aka.ms/vs/16/release/vs_community.exe /vs_community.exe
+RUN C:\vs_community.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended
 
-# install chocolatey
+# install chocolatey and use it to install cmake, git, conan, vim (vim for xxd only, since installing cygwin breaks docker)
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); `
+choco install -y cmake git conan vim
 
-# install cmake, git, conan, vim (for xxd only, since installing cygwin breaks docker)
-RUN choco install -y cmake git conan vim
+# configure path (add xxd and cmake), conan remotes, and fix windows path size limits for conan
+RUN [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Program Files\CMake\bin;C:\tools\vim\vim82', 'Machine'); `
+conan remote add eliza https://api.bintray.com/conan/eliza/conan; `
+conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan; `
+setx CONAN_USE_ALWAYS_SHORT_PATHS 1
 
-# add xxd and cmake to path
-#RUN [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Program Files\CMake\bin;C:\Program Files\CMake\bin;C:\tools\vim\vim82', 'Machine')
-RUN [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Program Files\CMake\bin;C:\tools\vim\vim82', 'Machine')
-
-# add conan remotes
-RUN conan remote add eliza https://api.bintray.com/conan/eliza/conan; `
-conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-
-# fix windows path size limits for conan
-# https://docs.conan.io/en/latest/reference/env_vars.html#conan-use-always-short-paths
-RUN setx CONAN_USE_ALWAYS_SHORT_PATHS 1
-
-# fix devenv not found when building sigc++
-# ugly hack to prevent the devenv /upgrade command from running
-# running it requires vs community, and it doesn't do anything anyway since the solution is already up to date
-RUN echo "\"REM bleh\"" | Set-Content C:\BuildTools\Common7\Tools\devenv.bat
-
-# start using vs buildtools
-# actually, f**k you, we aren't, cuz that's what has been screwing me over
-#SHELL ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&"]
-
-# start conan build dependencies
-# breaking this up to debug dependency issues easier without having to do 30 min rebuilds every time
-RUN conan install boost/1.73.0@_/_ --build=missing -o boost:without_test=True
-RUN conan install openal/1.18.2@bincrafters/stable --build=missing -o openal:shared=True
-RUN conan install physfs/3.0.1@bincrafters/stable --build=missing
-RUN conan install pixman/0.34.0@bincrafters/stable --build=missing
-RUN conan install ruby/2.5.3@eliza/testing --build=missing
-RUN conan install sdl2/2.0.9@bincrafters/stable --build=missing -o sdl2:shared=True
-# override sdl2 version when building sdl2_image
-RUN mkdir C:\Temp; echo "\"[requires]`nsdl2/2.0.9@bincrafters/stable`nsdl2_image/2.0.5@bincrafters/stable\"" | Set-Content C:\Temp\conanfile.txt; conan install C:\Temp sdl2_image/2.0.5@bincrafters/stable --build=missing; rm -r C:\Temp
-RUN conan install sdl2_ttf/2.0.15@bincrafters/stable --build=missing
-# override sdl2 version when building sdl2_sound-mkxp
-RUN mkdir C:\Temp; echo "\"[requires]`nsdl2/2.0.9@bincrafters/stable`nsdl_sound-mkxp/1.0.1@eliza/stable\"" | Set-Content C:\Temp\conanfile.txt; conan install C:\Temp sdl_sound-mkxp/1.0.1@eliza/stable --build=missing; rm -r C:\Temp
-# dont use the v120 toolchain for sigc++
-RUN conan install sigc++/2.10.0@bincrafters/stable --build=missing -s compiler.toolset=v142
+# prebuild all dependencies using the conanfile in this commit
+COPY conanfile.py C:/Temp/install_deps/
+RUN conan install --build=missing C:\Temp\install_deps
 
 # finally, we build oneshot when we run the container
 COPY build-entrypoint-windows.bat /

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -159,6 +159,10 @@ static void mriBindingInit()
 		rb_gv_set("TEST", debug);
 
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
+
+	// set environment variable for openssl to detect our cert bundle
+	// the 0 means it won't overwrite the variable if the user wants to set one
+	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -168,7 +168,7 @@ static void mriBindingInit()
 #ifdef _WIN32
 	char tmpbuf[2];
 	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
-		SetEnvironmentVariableA("SSL_CERT_FILE", ".\ssl\cacert.pem");
+		SetEnvironmentVariableA("SSL_CERT_FILE", ".\\ssl\\cacert.pem");
 	}
 #else
 	// the 0 means it won't overwrite the variable if the user wants to set one

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -41,6 +41,10 @@
 
 #include <SDL_filesystem.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 extern const char module_rpg1[];
 
 static void mriBindingExecute();
@@ -161,8 +165,15 @@ static void mriBindingInit()
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
 
 	// set environment variable for openssl to detect our cert bundle
+#ifdef _WIN32
+	char tmpbuf[2];
+	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
+		SetEnvironmentVariableA("SSL_CERT_FILE", ".\ssl\cacert.pem");
+	}
+#else
 	// the 0 means it won't overwrite the variable if the user wants to set one
 	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
+#endif
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -98,6 +98,12 @@ RB_METHOD(_kernelCaller);
 
 static void mriBindingInit()
 {
+	// setup ruby library paths
+	rb_eval_string(
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
+	);
+
 	tableBindingInit();
 	etcBindingInit();
 	fontBindingInit();

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -41,10 +41,6 @@
 
 #include <SDL_filesystem.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 extern const char module_rpg1[];
 
 static void mriBindingExecute();
@@ -165,15 +161,12 @@ static void mriBindingInit()
 	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
 
 	// set environment variable for openssl to detect our cert bundle
-#ifdef _WIN32
-	char tmpbuf[2];
-	if(GetEnvironmentVariableA("SSL_CERT_FILE", tmpbuf, 2) == 0) {
-		SetEnvironmentVariableA("SSL_CERT_FILE", ".\\ssl\\cacert.pem");
-	}
-#else
-	// the 0 means it won't overwrite the variable if the user wants to set one
-	setenv("SSL_CERT_FILE", "./ssl/cacert.pem", 0);
-#endif
+
+	rb_eval_string(
+		"if ENV['SSL_CERT_FILE'].nil?\n"
+		"    ENV['SSL_CERT_FILE'] = './ssl/cacert.pem'\n"
+		"end\n"
+	);
 }
 
 static void

--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -98,12 +98,6 @@ RB_METHOD(_kernelCaller);
 
 static void mriBindingInit()
 {
-	// setup ruby library paths
-	rb_eval_string(
-		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
-		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
-	);
-
 	tableBindingInit();
 	etcBindingInit();
 	fontBindingInit();
@@ -595,6 +589,22 @@ static void mriBindingExecute()
 	ruby_sysinit(&argc, &argv);
 
 	ruby_setup();
+
+	// setup ruby library paths
+	rb_eval_string(
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby'))\n"
+		"$LOAD_PATH.unshift(File.join(Dir.pwd, 'lib', 'ruby', RUBY_PLATFORM))\n"
+	);
+
+	// we probably should only be calling this if we are a ruby executable
+        // but we need to initialize things like the prelude (provides important library functions like IO#read_nonblock
+        // Init_prelude is not exposed anywhere else
+
+        // the three arguments are the executable name, and the '-e ""' is to tell ruby to run an empty file
+        // otherwise (since this parses options for the ruby executable) it's gonna wait on stdin for code
+        char* options_argv[] = {"oneshot", "-e", "", NULL};
+	ruby_options(3, options_argv);
+
 	rb_enc_set_default_external(rb_enc_from_encoding(rb_utf8_encoding()));
 
 	Config &conf = shState->rtData().config;

--- a/build-entrypoint-windows.bat
+++ b/build-entrypoint-windows.bat
@@ -12,8 +12,8 @@ conan install \work\src --build=missing || (echo CONAN INSTALL FAILED! && exit 1
 conan build \work\src || (echo CONAN BUILD FAILED! && goto end)
 :: TODO: compile the journal?
 
-robocopy C:\work\build\bin C:\work\dist
-robocopy C:\work\data C:\work\dist /e
+robocopy C:\work\build\bin C:\work\dist /e
+if exist C:\work\data (robocopy C:\work\data C:\work\dist /e)
 
 echo ModShot has been built. Enjoy.
 :end

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,6 +38,7 @@ class MkxpConan(ConanFile):
         "cygwin_installer:packages=xxd",
         # Avoid dead url bitrot in cygwin_installer
         "cygwin_installer:with_pear=False",
+        "ruby:with_openssl=True",
     )
 
     #def build_requirements(self):
@@ -108,3 +109,11 @@ class MkxpConan(ConanFile):
                  keep_path=True)
             if self.settings.build_type == "Debug":
                 copy("*.pdb", dst="bin", root_package=dep, keep_path=False)
+        # copy the ruby standard library
+	# this is a very ugly way of doing this (putting it in bin instead of lib)
+	# but this makes distributing mods easier, and also makes sure windows and linux are mostly the same
+        copy("*",
+            dst="bin/lib/ruby/",
+            src="lib/ruby/2.5.0/",
+            root_package="ruby",
+            keep_path=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,6 +92,10 @@ class MkxpConan(ConanFile):
         #    self.build_configure()
         self.build_configure()
 
+        # ship certificates into the ssl folder in the game directory
+        # openssl will use this folder since we hardcoded it in binding-mri.cpp
+        tools.download("https://curl.haxx.se/ca/cacert.pem", "bin/ssl/cacert.pem", overwrite=True)
+
     def package(self):
         self.copy("*", dst="bin", src="bin")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,6 +64,15 @@ class MkxpConan(ConanFile):
             self.options["sdl2"].shared = True
 
     def build_configure(self):
+        # if we are on windows, git might clone files using the CRLF newline
+        # this will cause issues when building for linux, as some scripts cannot run properly
+        # we run dos2unix on them to convert their line endings
+        for file in ['make-appimage.sh', 'assets/AppRun', 'assets/oneshot.desktop']:
+            try:
+                tools.dos2unix(os.path.join(self.source_folder, file))
+            except FileNotFoundError:
+                pass # in case windows users don't need those files
+
         cmake = CMake(self, msbuild_verbosity='minimal')
         if self.options.platform == "steam":
             cmake.definitions["STEAM"] = "ON"

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -45,8 +45,9 @@ $LINUXDEPLOY -e "$conan_install_path/bin/oneshot" \
 	     --custom-apprun="$source_path/assets/AppRun" \
 	     --appdir "$appdir"
 
-# Copy ruby standard library
+# Copy ruby standard library and ssl cert bundle
 cp -af "$conan_install_path/bin/lib/" "$appdir/usr/bin/lib"
+cp -af "$conan_install_path/bin/ssl/" "$appdir/usr/bin/ssl"
 
 # Bundle game data
 cp -af "$journal_file" "$appdir/usr/bin/_______"

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -45,6 +45,9 @@ $LINUXDEPLOY -e "$conan_install_path/bin/oneshot" \
 	     --custom-apprun="$source_path/assets/AppRun" \
 	     --appdir "$appdir"
 
+# Copy ruby standard library
+cp -af "$conan_install_path/bin/lib/" "$appdir/usr/bin/lib"
+
 # Bundle game data
 cp -af "$journal_file" "$appdir/usr/bin/_______"
 cp -af "$source_path/assets/journal.png" "$appdir/usr/bin/_______.png"


### PR DESCRIPTION
Please merge after #10.
Cleaned up the Dockerfiles and used the newer conanfile (with openssl support) to build the dependencies for Modshot. This should make compilation much quicker if you're using ModShot with openssl support.

These two images are already built and pushed to Docker Hub under `rkevin/build-oneshot-linux:with-openssl` and `rkevin/build/oneshot-windows:with-openssl`. The old `:latest` tags arre still the old images, for backwards compatibility. The build-windows github action should now use the `with-openssl` container by default.

Also started adding the git commit hash to the artifact in the `build-windows-baremetal` github action.