### PR TITLE
Placate compiler and fix #13

### DIFF
--- a/binding-mri/graphics-binding.cpp
+++ b/binding-mri/graphics-binding.cpp
@@ -28,6 +28,7 @@
 
 void* invokeGraphicsUpdate(void* unused) {
 	shState->graphics().update();
+	return NULL;
 }
 
 RB_METHOD(graphicsUpdate)


### PR DESCRIPTION
Apparently the windows C++ compiler is mad at something that GCC is fine with.

In retrospect, GCC absolutely shouldn't be fine with an error like this. Huh.