### PR TITLE
Build AppDir instead of AppImage on Linux, and add Linux compilation github action

### DIFF
--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -4,6 +4,8 @@ jobs:
   build-linux:
     name: Build ModShot for Linux
     runs-on: ubuntu-latest
+    env:
+      CONAN_USER_HOME: /tmp/conan-build-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,7 +26,7 @@ jobs:
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.conan
+          path: /tmp/conan-build-cache
           key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
       - name: Build dependencies using conan
         run: conan install ${{ github.workspace }} --build=missing

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
-          libgtk2.0-dev libxfconf-0-dev &&
+          libgtk2.0-dev libxfconf-0-dev libwmf0.2-7-gtk &&
           sudo curl -Lo /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage &&
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
       - name: Setup Python

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -11,7 +11,7 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
           libgtk2.0-dev libxfconf-0-dev &&
-          sudo curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage &&
+          sudo curl -Lo /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage &&
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -7,7 +7,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt install -y \
+          libgtk2.0-dev libxfconf-0-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
       - name: Install and configure conan
         run: |
           pip3 install conan

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -11,7 +11,7 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
           libgtk2.0-dev libxfconf-0-dev &&
-          curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          sudo curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Install and configure conan

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -10,7 +10,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
-          libgtk2.0-dev libxfconf-0-dev
+          libgtk2.0-dev libxfconf-0-dev &&
+          curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Install and configure conan

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -4,15 +4,13 @@ jobs:
   build-linux:
     name: Build ModShot for Linux
     runs-on: ubuntu-latest
-    env:
-      CONAN_USER_HOME: /tmp/conan-build-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
-          libgtk2.0-dev libxfconf-0-dev libwmf0.2-7-gtk &&
+          libgtk2.0-dev libxfconf-0-dev libwmf0.2-7-gtk libegl1-mesa-dev libgbm-dev libasound2-dev libjack-dev libpulse-dev libaudio-dev &&
           sudo curl -Lo /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage &&
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
       - name: Setup Python
@@ -26,7 +24,7 @@ jobs:
       - name: Cache conan dependencies
         uses: actions/cache@v2
         with:
-          path: /tmp/conan-build-cache
+          path: ~/.conan
           key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
       - name: Build dependencies using conan
         run: conan install ${{ github.workspace }} --build=missing

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -11,7 +11,8 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt install -y \
           libgtk2.0-dev libxfconf-0-dev &&
-          sudo curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          sudo curl -o /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage &&
+          sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Install and configure conan

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
       - name: Install and configure conan
         run: |
           pip3 install conan

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -1,0 +1,35 @@
+name: build-linux-baremetal
+on: push
+jobs:
+  build-linux:
+    name: Build ModShot for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install and configure conan
+        run: |
+          pip3 install conan
+          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
+          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          mkdir ${{ runner.temp }}/build
+      - name: Cache conan dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.conan
+          key: ${{ runner.os }}-cached-conan-modules-${{ hashFiles('conanfile.py') }}
+      - name: Build dependencies using conan
+        run: conan install ${{ github.workspace }} --build=missing
+        working-directory: ${{ runner.temp }}/build
+      - name: Build ModShot
+        run: conan build ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}/build
+      - name: Create AppDir
+        run: |
+          mkdir ${{ runner.temp }}/dist &&
+          ${{ github.workspace }}/make-linux-appdir.sh ${{ github.workspace }} ${{ runner.temp }}/build ${{ runner.temp }}/dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modshot_build_linux_${{ github.sha }}
+          path: ${{ runner.temp }}/dist

--- a/.github/workflows/build-linux-baremetal.yaml
+++ b/.github/workflows/build-linux-baremetal.yaml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          DEBIAN_FRONTEND=noninteractive apt install -y \
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y \
           libgtk2.0-dev libxfconf-0-dev
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -22,8 +22,7 @@ RUN cd /tmp && sudo chmod 755 appimagetool-x86_64.AppImage linuxdeploy-x86_64.Ap
 sudo ln -s /usr/local/bin/appimagetool/AppRun /usr/local/bin/appimagetool-x86_64.AppImage && \
 sudo ln -s /usr/local/bin/linuxdeploy/AppRun /usr/local/bin/linuxdeploy-x86_64.AppImage
 
-COPY build-entrypoint-linux.sh /
-ENTRYPOINT ["/build-entrypoint-linux.sh"]
+ENTRYPOINT ["/work/src/build-entrypoint-linux.sh"]
 
 # build this docker image as follows:
 # docker build -t oneshot-build-linux .

--- a/assets/AppRun
+++ b/assets/AppRun
@@ -10,4 +10,5 @@ sed "s,%RETARGET%,$appdir_lib_escaped," \
     "$APPDIR/usr/lib/loaders.cache" > "$temp_gdk_loaders_cache"
 export GDK_PIXBUF_MODULE_FILE="$temp_gdk_loaders_cache"
 
-"$APPDIR/usr/bin/oneshot"
+cd ($dirname $0)
+"./usr/bin/oneshot"

--- a/build-entrypoint-linux.sh
+++ b/build-entrypoint-linux.sh
@@ -16,13 +16,4 @@ cd /work/build
 conan install /work/src --build=missing
 conan build /work/src
 
-# build journal if doesn't exist
-[ ! -f /work/build/_______ ] && eval "$(pyenv init -)" && \
-pyinstaller --onefile \
-            --distpath /work/build \
-            --workpath `mktemp -d` \
-            --specpath=/work/src/journal/unix \
-            /work/src/journal/unix/journal-linux.spec
-
-# build appimage
-/work/src/make-appimage.sh /work/src /work/build /work/data /work/extra_unix_content /work/build/_______ /work/dist/ModShot.AppImage
+/work/src/make-linux-appdir.sh /work/src /work/build /work/dist

--- a/make-linux-appdir.sh
+++ b/make-linux-appdir.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+
+LINUXDEPLOY=linuxdeploy-x86_64.AppImage
+GDK_LOADERS_PATH=/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0
+
+if [ $# -lt 3 ]; then
+  echo "usage: make-linux-appdir.sh SOURCE_PATH CONAN_INSTALL_PATH APPDIR"
+  exit 1
+fi
+
+source_path="$1"
+conan_install_path="$2"
+appdir="$3"
+
+$LINUXDEPLOY -e "$conan_install_path/bin/oneshot" \
+	     -l "$conan_install_path/lib/libruby.so.2.5.3" \
+	     -l "$GDK_LOADERS_PATH/loaders/io-wmf.so" \
+             -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-bmp.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-icns.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-jpeg.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-pnm.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-svg.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-tiff.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-xpm.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-ani.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-gif.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-ico.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-png.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-qtif.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-tga.so" \
+	     -l "$GDK_LOADERS_PATH/loaders/libpixbufloader-xbm.so" \
+	     -i "$source_path/assets/oneshot.png" \
+	     -d "$source_path/assets/oneshot.desktop" \
+	     --custom-apprun="$source_path/assets/AppRun" \
+	     --appdir "$appdir"
+
+# Copy ruby standard library and ssl cert bundle
+cp -af "$conan_install_path/bin/lib/" "$appdir/usr/bin/lib"
+cp -af "$conan_install_path/bin/ssl/" "$appdir/usr/bin/ssl"
+
+# GDK pixbuf retarget nonsense
+sed "s,$GDK_LOADERS_PATH/loaders/,%RETARGET%/," \
+    "$GDK_LOADERS_PATH/loaders.cache" > "$appdir/usr/lib/loaders.cache"


### PR DESCRIPTION
As title. The Github action should take 10-15mins to build without a cache, and 3-4mins to build with a cache. Journal compilation is disabled.

BTW, I have repushed the `rkevin/build-oneshot-linux:with-openssl` docker container, and you should repull using `docker pull rkevin/build-oneshot-linux:with-openssl`. All I changed is to always use the `build-entrypoint-linux.sh` that's in the mounted source directory, and not use a hardcoded entrypoint at container build time. Since this PR changed the build entrypoint, you should repull the build container.