### PR TITLE
Fix windows shim chdir issue

### DIFF
--- a/windows/shim.c
+++ b/windows/shim.c
@@ -1,5 +1,7 @@
 #include <windows.h>
 #include <wchar.h>
+#include <errno.h>
+#include <stdio.h>
 
 const wchar_t *ARGV0 = "lib\\oneshot.exe";
 
@@ -19,7 +21,17 @@ int WINAPI WinMain(HINSTANCE hInstance,
     if (hModule != NULL) {
         wchar_t *oneshotDir[MAX_PATH];
         GetModuleFileNameW(hModule, oneshotDir, sizeof(oneshotDir));
-        _wchdir(oneshotDir);
+        wchar_t *pathend = wcsrchr(oneshotDir, L'\\');
+        if(pathend != NULL) {
+            *pathend = L'\0';
+        }
+        if(_wchdir(oneshotDir)) {
+            MessageBoxW(NULL,
+                L"Changing working directory failed. This should never happen.\nFind rkevin and beat him with a stick.",
+                L"ModShot Shim",
+                MB_ICONERROR);
+            printf("chdir errno: %d", errno);
+        }
     }
 
     if (argc != 0) {


### PR DESCRIPTION
Fixed an issue causing the windows `modshot-shim` to not be able to switch its current directory, which made it fail when not run from the game directory