### PR TITLE
Add force quit feature

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -92,6 +92,7 @@ RB_METHOD(mkxpDataDirectory);
 RB_METHOD(mkxpPuts);
 RB_METHOD(mkxpRawKeyStates);
 RB_METHOD(mkxpMouseInWindow);
+RB_METHOD(mkxpAllowForceQuit);
 
 RB_METHOD(mriRgssMain);
 RB_METHOD(mriRgssStop);
@@ -150,6 +151,7 @@ static void mriBindingInit()
 	_rb_define_module_function(mod, "puts", mkxpPuts);
 	_rb_define_module_function(mod, "raw_key_states", mkxpRawKeyStates);
 	_rb_define_module_function(mod, "mouse_in_window", mkxpMouseInWindow);
+	_rb_define_module_function(mod, "allow_force_quit", mkxpAllowForceQuit);
 
 	/* Load global constants */
 	rb_gv_set("MKXP", Qtrue);
@@ -254,6 +256,12 @@ RB_METHOD(mkxpMouseInWindow)
 	RB_UNUSED_PARAM;
 
 	return rb_bool_new(EventThread::mouseState.inWindow);
+}
+
+RB_METHOD(mkxpAllowForceQuit) {
+	RB_UNUSED_PARAM;
+	shState->rtData().allowForceQuit.set();
+	return Qnil;
 }
 
 static VALUE rgssMainCb(VALUE block)

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -348,6 +348,12 @@ void EventThread::process(RGSSThreadData &rtData)
 				break;
 			}
 
+			if (event.key.keysym.scancode == SDL_SCANCODE_F3 && rtData.allowForceQuit) {
+				// ModShot addition: force quit the game, no prompting or saving
+				terminate = true;
+				break;
+			}
+
 			if (event.key.keysym.scancode == SDL_SCANCODE_F12)
 			{
 				if (!rtData.config.debugMode)

--- a/src/eventthread.h
+++ b/src/eventthread.h
@@ -251,6 +251,9 @@ struct RGSSThreadData
 	/* True if accepting text input */
 	AtomicFlag acceptingTextInput;
 
+	/* True if allow force quit */
+	AtomicFlag allowForceQuit;
+
 	EventThread *ethread;
 	UnidirMessage<Vec2i> windowSizeMsg;
 	UnidirMessage<BDescVec> bindingUpdateMsg;


### PR DESCRIPTION
With this, if you call the `MKXP.allow_force_quit` function once in your code (maybe when you set `$debug` to be true), the game will force quit when you press F3 (no prompts, no saving, no nothing). If `MKXP.allow_force_quit` isn't called before then F3 does nothing.