### PR TITLE
Placate compiler warning about argv passed into ruby_options

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -607,12 +607,13 @@ static void mriBindingExecute()
 	);
 
 	// we probably should only be calling this if we are a ruby executable
-        // but we need to initialize things like the prelude (provides important library functions like IO#read_nonblock
-        // Init_prelude is not exposed anywhere else
+	// but we need to initialize things like the prelude (provides important library functions like IO#read_nonblock
+	// Init_prelude is not exposed anywhere else
 
-        // the three arguments are the executable name, and the '-e ""' is to tell ruby to run an empty file
-        // otherwise (since this parses options for the ruby executable) it's gonna wait on stdin for code
-        char* options_argv[] = {"oneshot", "-e", "", NULL};
+	// the three arguments are the executable name, and the '-e ""' is to tell ruby to run an empty file
+	// otherwise (since this parses options for the ruby executable) it's gonna wait on stdin for code
+	char options_argv1[] = "oneshot", options_argv2[] = "-e", options_argv3[] = "";
+	char* options_argv[] = {options_argv1, options_argv2, options_argv3, NULL};
 	ruby_options(3, options_argv);
 
 	rb_enc_set_default_external(rb_enc_from_encoding(rb_utf8_encoding()));


### PR DESCRIPTION
Nothing important, I've just been seeing this for a while and got tired of it. ~~Also I know there's 3 million compiler warnings on windows but I have decided not to care~~