### PR TITLE
More violent forcequit

### DIFF
--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -85,6 +85,7 @@ EventThread::JoyState EventThread::joyState;
 EventThread::MouseState EventThread::mouseState;
 EventThread::TouchState EventThread::touchState;
 SDL_mutex *EventThread::inputMut;
+bool EventThread::forceTerminate;
 
 /* User event codes */
 enum
@@ -350,7 +351,9 @@ void EventThread::process(RGSSThreadData &rtData)
 
 			if (event.key.keysym.scancode == SDL_SCANCODE_F3 && rtData.allowForceQuit) {
 				// ModShot addition: force quit the game, no prompting or saving
+				Debug() << "Force terminating ModShot";
 				terminate = true;
+				EventThread::forceTerminate = true;
 				break;
 			}
 

--- a/src/eventthread.h
+++ b/src/eventthread.h
@@ -84,6 +84,7 @@ public:
 	static JoyState joyState;
 	static MouseState mouseState;
 	static TouchState touchState;
+	static bool forceTerminate;
 
 	static bool allocUserEvents();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,36 +361,38 @@ int main(int argc, char *argv[])
 	/* Start event processing */
 	eventThread.process(rtData);
 
-	/* Request RGSS thread to stop */
-	rtData.rqTerm.set();
+	if(!EventThread::forceTerminate) {
+		/* Request RGSS thread to stop */
+		rtData.rqTerm.set();
 
-	/* Wait for RGSS thread response */
-	for (int i = 0; i < 1000; ++i)
-	{
-		/* We can stop waiting when the request was ack'd */
-		if (rtData.rqTermAck)
+		/* Wait for RGSS thread response */
+		for (int i = 0; i < 1000; ++i)
 		{
-			Debug() << "RGSS thread ack'd request after" << i*10 << "ms";
-			break;
+			/* We can stop waiting when the request was ack'd */
+			if (rtData.rqTermAck)
+			{
+				Debug() << "RGSS thread ack'd request after" << i*10 << "ms";
+				break;
+			}
+
+			/* Give RGSS thread some time to respond */
+			SDL_Delay(10);
 		}
 
-		/* Give RGSS thread some time to respond */
-		SDL_Delay(10);
-	}
+		/* If RGSS thread ack'd request, wait for it to shutdown,
+		* otherwise abandon hope and just end the process as is. */
+		if (rtData.rqTermAck)
+			SDL_WaitThread(rgssThread, 0);
+		else
+			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, conf.windowTitle.c_str(),
+									"The RGSS script seems to be stuck and OneShot will now force quit", win);
 
-	/* If RGSS thread ack'd request, wait for it to shutdown,
-	 * otherwise abandon hope and just end the process as is. */
-	if (rtData.rqTermAck)
-		SDL_WaitThread(rgssThread, 0);
-	else
-		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, conf.windowTitle.c_str(),
-		                         "The RGSS script seems to be stuck and OneShot will now force quit", win);
-
-	if (!rtData.rgssErrorMsg.empty())
-	{
-		Debug() << rtData.rgssErrorMsg;
-		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, conf.windowTitle.c_str(),
-		                         rtData.rgssErrorMsg.c_str(), win);
+		if (!rtData.rgssErrorMsg.empty())
+		{
+			Debug() << rtData.rgssErrorMsg;
+			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, conf.windowTitle.c_str(),
+									rtData.rgssErrorMsg.c_str(), win);
+		}
 	}
 
 	/* Clean up any remainin events */


### PR DESCRIPTION
The old forcequit feature waits for the RGSS thread to ack the request, then will gracefully exit the game on the next call of `Graphics.update`. In case the RGSS thread goes in an infinite loop, the forcequit feature now actually force quits the process, without waiting for the RGSS thread. Be warned if the RGSS thread is in the middle of some I/O (including not closing opened files properly), data corruption may occur.