### PR TITLE
Fix buttoncode off by one issue

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 #include <assert.h>
 
-#define BUTTON_CODE_COUNT 259
+#define BUTTON_CODE_COUNT 260
 // SDLK can range from 0x00 to 0x7f for ones with character representation
 // and 0x40000039 to 0x4000011a for ones without character representation
 // we squash 0x40000039 - 0x4000007f to 0x139 - 0x17f


### PR DESCRIPTION
Accidentally didn't make the keystates buffer big enough, so whenever accessing the `SDLK_MUTE` key it will cause memory corruption