### PR TITLE
Audio channels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MAIN_HEADERS
 	src/aldatasource.h
 	src/alstream.h
 	src/audiostream.h
+	src/audiochannels.h
 	src/rgssad.h
 	src/sdl-util.h
 	src/oneshot.h
@@ -116,6 +117,7 @@ set(MAIN_SOURCE
 	src/sdlsoundsource.cpp
 	src/alstream.cpp
 	src/audiostream.cpp
+	src/audiochannels.cpp
 	src/rgssad.cpp
 	src/vorbissource.cpp
 	src/oneshot.cpp

--- a/binding-mri/aleffect-binding.cpp
+++ b/binding-mri/aleffect-binding.cpp
@@ -59,7 +59,7 @@
 	}
 
 #define ALEFFECT_CREATE_CLASS(type) \
-	VALUE rb_c##type = rb_define_class_under(module, #type, rb_cObject); \
+	VALUE rb_c##type = rb_define_class_under(module, #type, rb_cAlEffect); \
 	_rb_define_method(rb_c##type, "initialize", rb_aleffect_##type##_init); \
 	_rb_define_method(rb_c##type, "create_underlying_effect", rb_aleffect_##type##_createUnderlyingEffect);
 
@@ -569,6 +569,7 @@ ALEFFECT_DEFINE_PRESET(EFX_REVERB_PRESET_SMALLWATERROOM, smallwaterroom)
 void aleffectBindingInit()
 {
 	VALUE module = rb_define_module("ALEffect");
+	VALUE rb_cAlEffect = rb_define_class_under(module, "ALEffect", rb_cObject);
 
 	ALEFFECT_CREATE_CLASS(EAXReverb)
 	ALEFFECT_EXPOSE_ATTRIBUTE(EAXReverb, density)

--- a/binding-mri/audio-binding.cpp
+++ b/binding-mri/audio-binding.cpp
@@ -239,6 +239,20 @@ AL::Filter::ID constructALFilter(int argc, VALUE *argv) {
 		shState->audio().set##entity##GlobalVolume(vol); \
 		return Qnil; \
 	} \
+	RB_METHOD(audio_##entity##getPitch) \
+	{ \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		return rb_float_new(shState->audio().get##entity##Pitch(id)); \
+	} \
+	RB_METHOD(audio_##entity##setPitch) \
+	{ \
+		unsigned int id; \
+		double pitch; \
+		rb_get_args(argc, argv, "if", &id, &pitch RB_ARG_END); \
+		shState->audio().set##entity##Pitch(id, pitch); \
+		return Qnil; \
+	} \
 	RB_METHOD(audio_##entity##SetALFilter) { \
 		unsigned int id; \
 		rb_get_args(argc, argv, "i|", &id RB_ARG_END); \
@@ -363,6 +377,8 @@ RB_METHOD(audioReset)
 	_rb_define_module_function(module, #entity "_set_volume", audio_##entity##setVolume); \
 	_rb_define_module_function(module, #entity "_get_global_volume", audio_##entity##getGlobalVolume); \
 	_rb_define_module_function(module, #entity "_set_global_volume", audio_##entity##setGlobalVolume); \
+	_rb_define_module_function(module, #entity "_get_pitch", audio_##entity##getPitch); \
+	_rb_define_module_function(module, #entity "_set_pitch", audio_##entity##setPitch); \
 	_rb_define_module_function(module, #entity "_set_al_filter", audio_##entity##SetALFilter); \
 	_rb_define_module_function(module, #entity "_clear_al_filter", audio_##entity##ClearALFilter); \
 	_rb_define_module_function(module, #entity "_set_al_effect", audio_##entity##SetALEffect); \

--- a/binding-mri/audio-binding.cpp
+++ b/binding-mri/audio-binding.cpp
@@ -159,7 +159,125 @@ AL::Filter::ID constructALFilter(int argc, VALUE *argv) {
 	RB_METHOD(audio_##entity##ClearALEffect) { \
 		shState->audio().entity##ClearALEffect(); \
 		return Qnil; \
+	}
+
+#define DEF_ALL_AUDIO_CH_FUNC(entity) \
+	RB_METHOD(audio_##entity##Play) \
+	{ \
+		unsigned int id; \
+		const char *filename; \
+		int volume = 100; \
+		int pitch = 100; \
+		double pos = -1.0; \
+		bool fadeInOnOffset = true; \
+		rb_get_args(argc, argv, "iz|iifb", &id, &filename, &volume, &pitch, &pos, &fadeInOnOffset RB_ARG_END); \
+		GUARD_EXC( shState->audio().entity##Play(id, filename, volume, pitch, pos, fadeInOnOffset); ) \
+		return Qnil; \
 	} \
+	RB_METHOD(audio_##entity##Stop) \
+	{ \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		shState->audio().entity##Stop(id); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##Pos) \
+	{ \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		return rb_float_new(shState->audio().entity##Pos(id)); \
+	} \
+	RB_METHOD(audio_##entity##Fade) \
+	{ \
+		unsigned int id; \
+		int time; \
+		rb_get_args(argc, argv, "ii", &id, &time RB_ARG_END); \
+		shState->audio().entity##Fade(id, time); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##Crossfade) \
+	{ \
+		unsigned int id; \
+		const char *filename; \
+		double time = 2; \
+		int volume = 100; \
+		int pitch = 100; \
+		double pos = -1.0; \
+		rb_get_args(argc, argv, "iz|fiif", &id, &filename, &time, &volume, &pitch, &pos RB_ARG_END); \
+		GUARD_EXC(shState->audio().entity##Crossfade(id, filename, time, volume, pitch, pos);) \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##IsPlaying) \
+	{ \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		return shState->audio().entity##IsPlaying(id) ? Qtrue : Qfalse; \
+	} \
+	RB_METHOD(audio_##entity##getVolume) \
+	{ \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		return rb_float_new(shState->audio().get##entity##Volume(id)); \
+	} \
+	RB_METHOD(audio_##entity##setVolume) \
+	{ \
+		unsigned int id; \
+		double vol; \
+		rb_get_args(argc, argv, "if", &id, &vol RB_ARG_END); \
+		shState->audio().set##entity##Volume(id, vol); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##getGlobalVolume) \
+	{ \
+		RB_UNUSED_PARAM; \
+		return rb_float_new(shState->audio().get##entity##GlobalVolume()); \
+	} \
+	RB_METHOD(audio_##entity##setGlobalVolume) \
+	{ \
+		double vol; \
+		rb_get_args(argc, argv, "f", &vol RB_ARG_END); \
+		shState->audio().set##entity##GlobalVolume(vol); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##SetALFilter) { \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i|", &id RB_ARG_END); \
+		argc--; \
+		argv++; \
+		AL::Filter::ID filter = constructALFilter(argc, argv); \
+		shState->audio().entity##SetALFilter(id, filter); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##ClearALFilter) { \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		shState->audio().entity##ClearALFilter(id); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##SetALEffect) { \
+		unsigned int id; \
+		VALUE effect_obj; \
+		rb_get_args(argc, argv, "io", &id, &effect_obj RB_ARG_END); \
+		ALuint effect = NUM2INT(rb_funcall(effect_obj, rb_intern("create_underlying_effect"), 0)); \
+		shState->audio().entity##SetALEffect(id, effect); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##ClearALEffect) { \
+		unsigned int id; \
+		rb_get_args(argc, argv, "i", &id RB_ARG_END); \
+		shState->audio().entity##ClearALEffect(id); \
+		return Qnil; \
+	} \
+	RB_METHOD(audio_##entity##Size) { \
+		RB_UNUSED_PARAM; \
+		return INT2NUM(shState->audio().entity##Size()); \
+	} \
+	RB_METHOD(audio_##entity##Resize) { \
+		unsigned int size; \
+		rb_get_args(argc, argv, "i", &size RB_ARG_END); \
+		shState->audio().entity##Resize(size); \
+		return Qnil; \
+	}
 
 DEF_PLAY_STOP_POS( bgm )
 DEF_PLAY_STOP_POS( bgs )
@@ -187,6 +305,9 @@ DEF_AUD_ALFILTER(bgm)
 DEF_AUD_ALFILTER(bgs)
 DEF_AUD_ALFILTER(me)
 DEF_AUD_ALFILTER(se)
+
+DEF_ALL_AUDIO_CH_FUNC(lch)
+DEF_ALL_AUDIO_CH_FUNC(ch)
 
 RB_METHOD(audioReset)
 {
@@ -229,7 +350,25 @@ RB_METHOD(audioReset)
 	_rb_define_module_function(module, #entity "_set_al_filter", audio_##entity##SetALFilter); \
 	_rb_define_module_function(module, #entity "_clear_al_filter", audio_##entity##ClearALFilter); \
 	_rb_define_module_function(module, #entity "_set_al_effect", audio_##entity##SetALEffect); \
+	_rb_define_module_function(module, #entity "_clear_al_effect", audio_##entity##ClearALEffect);
+
+#define BIND_ALL_AUDIO_CH_FUNC(entity) \
+	_rb_define_module_function(module, #entity "_play", audio_##entity##Play); \
+	_rb_define_module_function(module, #entity "_stop", audio_##entity##Stop); \
+	_rb_define_module_function(module, #entity "_pos", audio_##entity##Pos); \
+	_rb_define_module_function(module, #entity "_fade", audio_##entity##Fade); \
+	_rb_define_module_function(module, #entity "_crossfade", audio_##entity##Crossfade); \
+	_rb_define_module_function(module, #entity "_playing?", audio_##entity##IsPlaying); \
+	_rb_define_module_function(module, #entity "_get_volume", audio_##entity##getVolume); \
+	_rb_define_module_function(module, #entity "_set_volume", audio_##entity##setVolume); \
+	_rb_define_module_function(module, #entity "_get_global_volume", audio_##entity##getGlobalVolume); \
+	_rb_define_module_function(module, #entity "_set_global_volume", audio_##entity##setGlobalVolume); \
+	_rb_define_module_function(module, #entity "_set_al_filter", audio_##entity##SetALFilter); \
+	_rb_define_module_function(module, #entity "_clear_al_filter", audio_##entity##ClearALFilter); \
+	_rb_define_module_function(module, #entity "_set_al_effect", audio_##entity##SetALEffect); \
 	_rb_define_module_function(module, #entity "_clear_al_effect", audio_##entity##ClearALEffect); \
+	_rb_define_module_function(module, #entity "_size", audio_##entity##Size); \
+	_rb_define_module_function(module, #entity "_resize", audio_##entity##Resize); \
 
 void
 audioBindingInit()
@@ -253,6 +392,9 @@ audioBindingInit()
 	BIND_AUDIO_ALFILTER(bgs);
 	BIND_AUDIO_ALFILTER(me);
 	BIND_AUDIO_ALFILTER(se);
+
+	BIND_ALL_AUDIO_CH_FUNC(lch)
+	BIND_ALL_AUDIO_CH_FUNC(ch)
 
 	_rb_define_module_function(module, "__reset__", audioReset);
 

--- a/src/alstream.cpp
+++ b/src/alstream.cpp
@@ -299,7 +299,7 @@ void ALStream::startStream(float offset)
 	threadTermReq.clear();
 
 	startOffset = offset<0 ? 0 : offset;
-	procFrames = offset * source->sampleRate();
+	procFrames = startOffset * source->sampleRate();
 
 	needsRewind = true;
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -517,8 +517,15 @@ AUDIO_CPP_DEF_ALFILTER_FUNCS(se)
 		return p->entity.getGlobalVolume() * 100; \
 	} \
 	\
-	void Audio::set##entity##GlobalVolume(float vol) { \
-		p->entity.setGlobalVolume(vol / 100); \
+	void Audio::set##entity##GlobalVolume(float volume) { \
+		p->entity.setGlobalVolume(volume / 100); \
+	} \
+	float Audio::get##entity##Pitch(unsigned int id) { \
+		return p->entity.getPitch(id) * 100; \
+	} \
+	\
+	void Audio::set##entity##Pitch(unsigned int id, float pitch) { \
+		p->entity.setPitch(id, pitch / 100); \
 	} \
 	unsigned int Audio::entity##Size() { \
 		return p->entity.size(); \

--- a/src/audio.h
+++ b/src/audio.h
@@ -68,6 +68,24 @@ public:
 	            int pitch = 100);
 	void seStop();
 
+	void lchPlay(unsigned int id,
+				 const char *filename,
+	             int volume = 100,
+	             int pitch = 100,
+	             float pos = -1,
+				 bool fadeInOnOffset = true);
+	void lchStop(unsigned int id);
+	void lchFade(unsigned int id, int time);
+
+	void chPlay(unsigned int id,
+				 const char *filename,
+	             int volume = 100,
+	             int pitch = 100,
+	             float pos = -1,
+				 bool fadeInOnOffset = true);
+	void chStop(unsigned int id);
+	void chFade(unsigned int id, int time);
+
 	void bgmCrossfade(const char *filename,
 				 	  float time = 2,
 			     	  int volume = 100,
@@ -83,13 +101,29 @@ public:
 			    	 int volume = 100,
 					 int pitch = 100,
 					 float offset = -1);
+	void lchCrossfade(unsigned int id,
+					  const char *filename,
+					  float time = 2,
+			    	  int volume = 100,
+					  int pitch = 100,
+					  float offset = -1);
+	void chCrossfade(unsigned int id,
+					  const char *filename,
+					  float time = 2,
+			    	  int volume = 100,
+					  int pitch = 100,
+					  float offset = -1);
 
 	float bgmPos();
 	float bgsPos();
+	float lchPos(unsigned int id);
+	float chPos(unsigned int id);
 
 	bool bgmIsPlaying();
 	bool bgsIsPlaying();
 	bool meIsPlaying();
+	bool lchIsPlaying(unsigned int id);
+	bool chIsPlaying(unsigned int id);
 
 #define AUDIO_H_DECL_ALFILTER_FUNCS(entity) \
 	void entity##SetALFilter(AL::Filter::ID filter); \
@@ -102,11 +136,31 @@ public:
 	AUDIO_H_DECL_ALFILTER_FUNCS(me)
 	AUDIO_H_DECL_ALFILTER_FUNCS(se)
 
+#define AUDIO_H_DECL_CH_ALFILER_FUNCS(entity) \
+	void entity##SetALFilter(unsigned int id, AL::Filter::ID filter); \
+	void entity##ClearALFilter(unsigned int id); \
+	void entity##SetALEffect(unsigned int id, ALuint effect); \
+	void entity##ClearALEffect(unsigned int id);
+
+	AUDIO_H_DECL_CH_ALFILER_FUNCS(lch)
+	AUDIO_H_DECL_CH_ALFILER_FUNCS(ch)
+
 	void reset();
 
-        /* Non-standard extension */
-	DECL_ATTR( BGM_Volume, int)
-        DECL_ATTR( SFX_Volume, int)
+    /* Non-standard extension */
+	DECL_ATTR(BGM_Volume, int)
+    DECL_ATTR(SFX_Volume, int)
+
+#define AUDIO_H_DECL_CH_SPECIAL_FUNCS(entity) \
+	float get##entity##Volume(unsigned int id); \
+	void set##entity##Volume(unsigned int id, float volume); \
+	float get##entity##GlobalVolume(); \
+	void set##entity##GlobalVolume(float volume); \
+	unsigned int entity##Size(); \
+	void entity##Resize(unsigned int size);
+
+	AUDIO_H_DECL_CH_SPECIAL_FUNCS(lch)
+	AUDIO_H_DECL_CH_SPECIAL_FUNCS(ch)
 
 private:
 	Audio(RGSSThreadData &rtData);

--- a/src/audio.h
+++ b/src/audio.h
@@ -156,6 +156,8 @@ public:
 	void set##entity##Volume(unsigned int id, float volume); \
 	float get##entity##GlobalVolume(); \
 	void set##entity##GlobalVolume(float volume); \
+	float get##entity##Pitch(unsigned int id); \
+	void set##entity##Pitch(unsigned int id, float pitch); \
 	unsigned int entity##Size(); \
 	void entity##Resize(unsigned int size);
 

--- a/src/audiochannels.cpp
+++ b/src/audiochannels.cpp
@@ -109,6 +109,20 @@ float AudioChannels::getVolume(unsigned int id, AudioStream::VolumeType type) {
     return streams[id]->getVolume(type);
 }
 
+void AudioChannels::setPitch(unsigned int id, float value) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id]->setPitch(value);
+}
+
+float AudioChannels::getPitch(unsigned int id) {
+    if (id >= streams.size()) {
+        return 0;
+    }
+    return streams[id]->getPitch();
+}
+
 float AudioChannels::playingOffset(unsigned int id) {
     if (id >= streams.size()) {
         return 0;

--- a/src/audiochannels.cpp
+++ b/src/audiochannels.cpp
@@ -1,0 +1,130 @@
+/*
+** audiochannels.cpp
+**
+** This file is part of ModShot.
+*/
+
+#include "audiochannels.h"
+AudioChannels::AudioChannels(ALStream::LoopMode loopMode,
+                             const std::string &threadId,
+                             unsigned int count):
+                             loopMode(loopMode),
+                             threadId(threadId),
+                             globalVolume(1.0f) {
+    for (int i=0; i<count; i++)
+        streams.emplace_back(loopMode, threadId + "_" + std::to_string(i));
+}
+
+unsigned int AudioChannels::size() {
+    return streams.size();
+}
+
+void AudioChannels::resize(unsigned int size) {
+    if (size < streams.size())
+        streams.erase(streams.begin() + size, streams.end());
+    else
+        for(int i = streams.size(); i < size; i++)
+            streams.emplace_back(loopMode, threadId + "_" + std::to_string(i));
+}
+
+float AudioChannels::getGlobalVolume() {
+    return globalVolume;
+}
+
+void AudioChannels::setGlobalVolume(float volume) {
+    for (AudioStream& stream : streams)
+        stream.setVolume(AudioStream::Base, stream.getVolume(AudioStream::Base) * volume / globalVolume);
+    globalVolume = volume;
+}
+
+void AudioChannels::play(unsigned int id,
+                        const std::string filename,
+	                    int volume,
+	                    int pitch,
+	                    float offset,
+			            bool fadeInOnOffset) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].play(filename, volume, pitch, offset, fadeInOnOffset);
+}
+
+void AudioChannels::crossfade(unsigned int id,
+                              const std::string &filename,
+			                  float time,
+			                  int volume,
+				              int pitch,
+				              float offset) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].crossfade(filename, time, volume, pitch, offset);
+}
+
+void AudioChannels::pause(unsigned int id) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].pause();
+}
+
+void AudioChannels::stop(unsigned int id) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].stop();
+}
+
+void AudioChannels::stopall() {
+    for (AudioStream& stream : streams)
+        stream.stop();
+}
+
+void AudioChannels::fadeOut(unsigned int id, int duration) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].fadeOut(duration);
+}
+
+void AudioChannels::setVolume(unsigned int id, AudioStream::VolumeType type, float value) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].setVolume(type, value);
+}
+
+float AudioChannels::getVolume(unsigned int id, AudioStream::VolumeType type) {
+    if (id >= streams.size()) {
+        return 0;
+    }
+    return streams[id].getVolume(type);
+}
+
+float AudioChannels::playingOffset(unsigned int id) {
+    if (id >= streams.size()) {
+        return 0;
+    }
+    return streams[id].playingOffset();
+}
+
+ALStream::State AudioChannels::queryState(unsigned int id) {
+    if (id >= streams.size()) {
+        return ALStream::State::Closed;
+    }
+    return streams[id].queryState();
+}
+
+void AudioChannels::setALFilter(unsigned int id, AL::Filter::ID filter) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].setALFilter(filter);
+}
+
+void AudioChannels::setALEffect(unsigned int id, ALuint effect) {
+    if (id >= streams.size()) {
+        return;
+    }
+    streams[id].setALEffect(effect);
+}

--- a/src/audiochannels.h
+++ b/src/audiochannels.h
@@ -45,7 +45,7 @@ class AudioChannels {
 	void setALEffect(unsigned int id, ALuint effect);
 
     private:
-    std::vector<AudioStream> streams;
+    std::vector<AudioStream*> streams;
     ALStream::LoopMode loopMode;
     const std::string threadId;
     float globalVolume;

--- a/src/audiochannels.h
+++ b/src/audiochannels.h
@@ -1,0 +1,54 @@
+/*
+** audiochannels.h
+**
+** This file is part of ModShot.
+*/
+
+#ifndef AUDIOCHANNELS_H
+#define AUDIOCHANNELS_H
+
+#include "audiostream.h"
+#include <vector>
+
+class AudioChannels {
+    public:
+    AudioChannels(ALStream::LoopMode loopMode,
+	            const std::string &threadId,
+                unsigned int count);
+
+    unsigned int size();
+    void resize(unsigned int size);
+    float getGlobalVolume();
+    void setGlobalVolume(float volume);
+
+    void play(unsigned int id,
+              const std::string filename,
+	          int volume,
+	          int pitch,
+	          float offset = 0,
+			  bool fadeInOnOffset = true);
+    void crossfade(unsigned int id,
+                   const std::string &filename,
+				   float time,
+			       int volume,
+				   int pitch,
+				   float offset = 0);
+	void pause(unsigned int id);
+	void stop(unsigned int id);
+    void stopall();
+	void fadeOut(unsigned int id, int duration);
+	void setVolume(unsigned int id, AudioStream::VolumeType type, float value);
+	float getVolume(unsigned int id, AudioStream::VolumeType type);
+	float playingOffset(unsigned int id);
+	ALStream::State queryState(unsigned int id);
+	void setALFilter(unsigned int id, AL::Filter::ID filter);
+	void setALEffect(unsigned int id, ALuint effect);
+
+    private:
+    std::vector<AudioStream> streams;
+    ALStream::LoopMode loopMode;
+    const std::string threadId;
+    float globalVolume;
+};
+
+#endif // AUDIOCHANNELS_H

--- a/src/audiochannels.h
+++ b/src/audiochannels.h
@@ -39,6 +39,8 @@ class AudioChannels {
 	void fadeOut(unsigned int id, int duration);
 	void setVolume(unsigned int id, AudioStream::VolumeType type, float value);
 	float getVolume(unsigned int id, AudioStream::VolumeType type);
+	void setPitch(unsigned int id, float value);
+	float getPitch(unsigned int id);
 	float playingOffset(unsigned int id);
 	ALStream::State queryState(unsigned int id);
 	void setALFilter(unsigned int id, AL::Filter::ID filter);

--- a/src/audiostream.cpp
+++ b/src/audiostream.cpp
@@ -358,9 +358,25 @@ float AudioStream::getVolume(VolumeType type)
 	return volumes[type];
 }
 
+void AudioStream::setPitch(float value)
+{
+	lockStream();
+	streams[0].setPitch(value);
+	current.pitch = value;
+	unlockStream();
+}
+
+float AudioStream::getPitch()
+{
+	return current.pitch;
+}
+
 float AudioStream::playingOffset()
 {
-	return streams[0].queryOffset();
+	lockStream();
+	float result = streams[0].queryOffset();
+	unlockStream();
+	return result;
 }
 
 ALStream::State AudioStream::queryState()

--- a/src/audiostream.h
+++ b/src/audiostream.h
@@ -155,6 +155,9 @@ struct AudioStream
 	void setVolume(VolumeType type, float value);
 	float getVolume(VolumeType type);
 
+	void setPitch(float value);
+	float getPitch();
+
 	float playingOffset();
 	ALStream::State queryState();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -95,7 +95,8 @@ void Config::read(int argc, char *argv[])
 	PO_DESC(allowSymlinks, bool, false) \
 	PO_DESC(iconPath, std::string, "") \
 	PO_DESC(SE.sourceCount, int, 6) \
-	PO_DESC(pathCache, bool, true)
+	PO_DESC(audioChannels, int, 30) \
+	PO_DESC(pathCache, bool, true) \
 
 // Not gonna take your shit boost
 #define GUARD_ALL( exp ) try { exp } catch(...) {}

--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,8 @@ struct Config
 		int sourceCount;
 	} SE;
 
+	int audioChannels;
+
 	bool useScriptNames;
 
 	std::string customScript;


### PR DESCRIPTION
Note this is verified to compile (on linux) but I haven't tested this yet. Please test before merging. I'm also not sure about the ramifications of having so many idle threads and whether this would cause performance regressions or not, you should test that.

This PR adds audio channels to the `Audio` module. There are 2 types of channels, `lch` (looped channels) and `ch` (non looped channels). The `lch` channels behave nearly the same as BGM/BGS, except it's not affected by any BGM/BGS/ME/SE, or the overall BGM volume, and each have their own volume/effects controls. The `ch` channels behave similarly, except audio played on them is not looped.

You should be able to access audio channels using their channel IDs, which start at 0. For example, `Audio::bgm_play(filename)` plays the audio on the BGM stream, while `Audio::lch_play(0, filename)` plays the audio on the LCH stream number 0.

The full list of exposed functions is available [here](https://github.com/rkevin-arch/Modshot-Core/blob/8508ca2c5388057da70af262fa58765925149204/binding-mri/audio-binding.cpp#L355-L371), where `#entity` is either `lch` or `ch`. Most functions take in the channel ID as the first argument, and the rest is the same as their equivalent BGM/BGS functions. The exceptions include:
- `[l]ch_get_volume(id)` and `[l]ch_set_volume(id, volume)` gets/sets a channel's volume. 100 is full volume.
- `[l]ch_get_global_volume()` and `[l]ch_set_global_volume(volume)` gets/sets the global volume for all `lch`/`ch`s. 100 is full volume.
- `[l]ch_size()` and `[l]ch_resize(size)` gets/sets the total number of channels available. This starts off at 30 (and is [configurable](https://github.com/rkevin-arch/Modshot-Core/blob/8508ca2c5388057da70af262fa58765925149204/src/config.cpp#L98), and you can grow/shrink it.

TODO write better documentation.