### PR TITLE
Fix bintray deprecation

### DIFF
--- a/.github/workflows/build-standalone.yaml
+++ b/.github/workflows/build-standalone.yaml
@@ -16,8 +16,9 @@ jobs:
         run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan
         run: |
-          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
-          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          conan remote add eliza https://rkevin.jfrog.io/artifactory/api/conan/eliza;
+          conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan;
+          conan config set general.revisions_enabled=1;
           setx CONAN_USE_ALWAYS_SHORT_PATHS 1;
           mkdir ${{ runner.temp }}\build
       - name: Cache conan dependencies
@@ -59,8 +60,9 @@ jobs:
       - name: Install and configure conan
         run: |
           pip3 install conan
-          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
-          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          conan remote add eliza https://rkevin.jfrog.io/artifactory/api/conan/eliza;
+          conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan;
+          conan config set general.revisions_enabled=1;
           mkdir ${{ runner.temp }}/build
       - name: Cache conan dependencies
         uses: actions/cache@v2

--- a/.github/workflows/build-steam.yaml
+++ b/.github/workflows/build-steam.yaml
@@ -16,8 +16,9 @@ jobs:
         run: '[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\tools\vim\vim82", "Machine")'
       - name: Configure conan
         run: |
-          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
-          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          conan remote add eliza https://rkevin.jfrog.io/artifactory/api/conan/eliza;
+          conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan;
+          conan config set general.revisions_enabled=1;
           setx CONAN_USE_ALWAYS_SHORT_PATHS 1;
           mkdir ${{ runner.temp }}\build
       - name: Cache conan dependencies
@@ -58,8 +59,9 @@ jobs:
       - name: Install and configure conan
         run: |
           pip3 install conan
-          conan remote add eliza https://api.bintray.com/conan/eliza/conan;
-          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+          conan remote add eliza https://rkevin.jfrog.io/artifactory/api/conan/eliza;
+          conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan;
+          conan config set general.revisions_enabled=1;
           mkdir ${{ runner.temp }}/build
       - name: Cache conan dependencies
         uses: actions/cache@v2

--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -1,7 +1,8 @@
 # gcc10 doesn't like me, and it seems the official appimage is build using gcc 5.4.0-6ubuntu1~16.04.12
 FROM conanio/gcc5
-RUN conan remote add eliza "https://api.bintray.com/conan/eliza/conan" && \
-conan remote add bincrafters "https://api.bintray.com/conan/bincrafters/public-conan"
+RUN conan remote add eliza "https://rkevin.jfrog.io/artifactory/api/conan/eliza" && \
+conan remote add bincrafters "https://bincrafters.jfrog.io/artifactory/api/conan/public-conan" && \
+conan config set general.revisions_enabled=1
 
 RUN sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y \
 xorg-dev libx11-xcb-dev libxcb-render0-dev libxcb-render-util0-dev libgtk2.0-dev libxfconf-0-dev vim libwmf0.2-7-gtk librsvg2-common rsync patchelf dos2unix && \

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -14,8 +14,9 @@ choco install -y cmake git conan vim
 
 # configure path (add xxd and cmake), conan remotes, and fix windows path size limits for conan
 RUN [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Program Files\CMake\bin;C:\tools\vim\vim82', 'Machine'); `
-conan remote add eliza https://api.bintray.com/conan/eliza/conan; `
-conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan; `
+conan remote add eliza https://rkevin.jfrog.io/artifactory/api/conan/eliza; `
+conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan; `
+conan config set general.revisions_enabled=1; `
 setx CONAN_USE_ALWAYS_SHORT_PATHS 1
 
 # prebuild all dependencies using the conanfile in this commit

--- a/make-linux-dist.sh
+++ b/make-linux-dist.sh
@@ -18,7 +18,7 @@ function copy_dependencies() {
     if [[ $SO_PROCESSED =~ $1 ]]; then
         return
     fi
-    [[ ! $1 =~ ^[a-zA-Z0-9+\.-]*$ ]] && fail "The library $1 has weird characters!"
+    [[ ! $1 =~ ^[a-zA-Z0-9+\._-]*$ ]] && fail "The library $1 has weird characters!"
 
     SO_PROCESSED="$SO_PROCESSED $1"
     cp "$2" "$DESTDIR/$1"


### PR DESCRIPTION
This PR should fix the docker image and github workflows due to the deprecation of bintray. Bincrafters remote has changed, and I'm hosting Eliza's packages in my own repo.

Note that the `rkevin/build-oneshot-linux:1.3` and `rkevin/build-oneshot-windows:1.3` images have been pushed to dockerhub, and the `:latest` tags have been updated to point to 1.3. Please repull the images ASAP.