### PR TITLE
Add input.set_key, input.unset_key, input.get_all_pressed

### DIFF
--- a/binding-mri/input-binding.cpp
+++ b/binding-mri/input-binding.cpp
@@ -468,7 +468,7 @@ RB_METHOD(inputGetAllPressed)
 	VALUE res = rb_ary_new();
     for (size_t i = 0; i < buttonCodesN; i++) {
 		if (shState->input().isPressed(buttonCodes[i].val)) {
-            rb_ary_push(res, buttonCodes[i].val);
+            rb_ary_push(res, INT2FIX(buttonCodes[i].val));
 		}
 	}
 	return res;

--- a/binding-mri/input-binding.cpp
+++ b/binding-mri/input-binding.cpp
@@ -166,6 +166,22 @@ RB_METHOD(inputSetTextInput) {
 	return Qnil;
 }
 
+RB_METHOD(inputSetKey)
+{
+	RB_UNUSED_PARAM;
+	int num = getButtonArg(argc, argv);
+	shState->input().setKey(num);
+	return Qnil;
+}
+
+RB_METHOD(inputUnsetKey)
+{
+	RB_UNUSED_PARAM;
+	int num = getButtonArg(argc, argv);
+	shState->input().unsetKey(num);
+	return Qnil;
+}
+
 struct
 {
 	const char *str;
@@ -446,6 +462,18 @@ static elementsN(buttonCodes);
 #define INPUT_EXPOSE_KMOD(name) \
 	rb_const_set(module, rb_intern(#name), INT2FIX(name));
 
+RB_METHOD(inputGetAllPressed)
+{
+	RB_UNUSED_PARAM;
+	VALUE res = rb_ary_new();
+    for (size_t i = 0; i < buttonCodesN; i++) {
+		if (shState->input().isPressed(buttonCodes[i].val)) {
+            rb_ary_push(res, buttonCodes[i].val);
+		}
+	}
+	return res;
+}
+
 void
 inputBindingInit()
 {
@@ -468,6 +496,10 @@ inputBindingInit()
 	_rb_define_module_function(module, "stop_text_input", inputStopTextInput);
 	_rb_define_module_function(module, "text_input", inputTextInput);
 	_rb_define_module_function(module, "set_text_input", inputSetTextInput);
+
+	_rb_define_module_function(module, "get_all_pressed", inputGetAllPressed);
+	_rb_define_module_function(module, "set_key", inputSetKey);
+	_rb_define_module_function(module, "unset_key", inputUnsetKey);
 
 	if (rgssVer >= 3)
 	{

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -809,6 +809,8 @@ void Input::setKey(int button) {
 	ButtonState& state = p->getStateCheck(button);
 	state.pressed = true;
 	state.triggered = true;
+	updateDir4();
+	updateDir8();
 }
 
 void Input::unsetKey(int button) {
@@ -816,6 +818,8 @@ void Input::unsetKey(int button) {
 	state.pressed = false;
 	state.triggered = false;
 	state.repeated = false;
+	updateDir4();
+	updateDir8();
 }
 
 Input::~Input()

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -809,8 +809,8 @@ void Input::setKey(int button) {
 	ButtonState& state = p->getStateCheck(button);
 	state.pressed = true;
 	state.triggered = true;
-	updateDir4();
-	updateDir8();
+	p->updateDir4();
+	p->updateDir8();
 }
 
 void Input::unsetKey(int button) {
@@ -818,8 +818,8 @@ void Input::unsetKey(int button) {
 	state.pressed = false;
 	state.triggered = false;
 	state.repeated = false;
-	updateDir4();
-	updateDir8();
+	p->updateDir4();
+	p->updateDir8();
 }
 
 Input::~Input()

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -805,6 +805,19 @@ bool Input::hasQuit()
 	return p->triedExit;
 }
 
+void Input::setKey(int button) {
+	ButtonState& state = p->getStateCheck(button);
+	state.pressed = true;
+	state.triggered = true;
+}
+
+void Input::unsetKey(int button) {
+	ButtonState& state = p->getStateCheck(button);
+	state.pressed = false;
+	state.triggered = false;
+	state.repeated = false;
+}
+
 Input::~Input()
 {
 	delete p;

--- a/src/input.h
+++ b/src/input.h
@@ -319,6 +319,9 @@ public:
 
 	Uint16 modkeys;
 
+	void setKey(int button);
+	void unsetKey(int button);
+
 private:
 	Input(const RGSSThreadData &rtData);
 	~Input();


### PR DESCRIPTION
As title, part of #39 
`input.set_key` sets a key's pressed and triggered values, and `input.unset_key` unsets a key's pressed, triggered and repeated values. Both of these functions only last until the current frame finishes (basically until the next `input.update`)
`input.get_all_pressed` returns a list of integers (all the key codes that are currently pressed).
Note that I haven't tested these features, so you should test them and merge if it actually works for your use case