### PR TITLE
Fix dist library filtering in linux

### DIFF
--- a/make-linux-dist.sh
+++ b/make-linux-dist.sh
@@ -12,10 +12,10 @@ function fail() {
 }
 
 function copy_dependencies() {
-    if [[ $SO_BLACKLIST =~ $1 ]]; then
+    if [[ $SO_BLACKLIST == *"$1"* ]]; then
         return
     fi
-    if [[ $SO_PROCESSED =~ $1 ]]; then
+    if [[ $SO_PROCESSED == *"$1"* ]]; then
         return
     fi
     [[ ! $1 =~ ^[a-zA-Z0-9+\._-]*$ ]] && fail "The library $1 has weird characters!"


### PR DESCRIPTION
The old way of doing things didn't catch `libstdc++.so.6`, which causes crashes on some systems (i.e. mine). Currently the steam demo crashes on my machine unless I remove this file.