### PR TITLE
Win32 application manifests

### DIFF
--- a/binding-mri/oneshot-binding.cpp
+++ b/binding-mri/oneshot-binding.cpp
@@ -22,12 +22,10 @@ RB_METHOD(oneshotMsgBox)
 {
 	RB_UNUSED_PARAM;
 	int type;
-	VALUE body;
-	VALUE title = Qnil;
-	rb_get_args(argc, argv, "iS|S", &type, &body, &title RB_ARG_END);
-	std::string bodyStr = std::string(RSTRING_PTR(body), RSTRING_LEN(body));
-	std::string titleStr = (title == Qnil) ? "" : std::string(RSTRING_PTR(title), RSTRING_LEN(title));
-	return rb_bool_new(shState->oneshot().msgbox(type, bodyStr.c_str(), titleStr.c_str()));
+	const char *body;
+	const char *title = "";
+	rb_get_args(argc, argv, "iz|z", &type, &body, &title RB_ARG_END);
+	return rb_bool_new(shState->oneshot().msgbox(type, body, title));
 }
 
 RB_METHOD(oneshotTextInput)

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,16 @@ if compilers['cpp'].get_id() == 'clang'
 endif
 
 if host_system == 'windows'
+    # Win32 Subsystem and Operating System version
+    # (default: 6.00 - Windows Vista/7 and higher)
+    winnt_ver_args = [
+        '-Wl,--major-subsystem-version=6',
+        '-Wl,--minor-subsystem-version=0',
+        '-Wl,--major-os-version=6',
+        '-Wl,--minor-os-version=0'
+    ]
+    global_link_args += winnt_ver_args
+
     if compilers['cpp'].get_id() != 'clang'
         global_args += '-masm=intel'
     endif
@@ -128,6 +138,9 @@ if host_system == 'windows'
         sources: [
             'windows/shim.c',
             windows_resources
+        ],
+        link_args: [
+            winnt_ver_args
         ],
         win_subsystem: 'windows'
     )

--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,23 @@
-project('modshot', 'c', 'cpp', version: '1.0.0', meson_version: '>=0.56.0', default_options: ['cpp_std=c++14', 'buildtype=release'])
+# ModShot Meson project build file
+project(
+    'modshot',
+    ['c', 'cpp'],
+    version: '1.0.0',
+    license: 'GPL-2.0',
+    meson_version: '>=0.56.0',
+    default_options: [
+        'cpp_std=c++14',
+        'buildtype=release'
+    ]
+)
 
 host_system = host_machine.system()
 
-xxd = find_program('xxd', native: true)
+compilers = {
+    'cpp': meson.get_compiler('cpp')
+}
 
-compilers = {'cpp': meson.get_compiler('cpp')}
+xxd = find_program('xxd', native: true)
 
 global_sources = []
 global_dependencies = []
@@ -12,9 +25,10 @@ global_include_dirs = []
 global_args = []
 global_link_args = []
 
-sizeof = {'void*': compilers['cpp'].sizeof('void*'),
-          'long': compilers['cpp'].sizeof('long')
-         }
+sizeof = {
+    'void*': compilers['cpp'].sizeof('void*'),
+    'long': compilers['cpp'].sizeof('long')
+}
 win64 = (sizeof['void*'] != sizeof['long'])
 
 global_args += '-DHAVE_NANOSLEEP'
@@ -31,10 +45,24 @@ endif
 # ====================
 
 # Suppress warnings
-global_args += ['-Wno-non-virtual-dtor', '-Wno-reorder', '-Wno-uninitialized', '-Wno-unknown-pragmas', '-Wno-stringop-truncation', '-Wno-parentheses', '-Wno-sign-compare', '-Wno-misleading-indentation']
+global_args += [
+    '-Wno-non-virtual-dtor',
+    '-Wno-reorder',
+    '-Wno-uninitialized',
+    '-Wno-unknown-pragmas',
+    '-Wno-stringop-truncation',
+    '-Wno-parentheses',
+    '-Wno-sign-compare',
+    '-Wno-misleading-indentation'
+]
+
 if compilers['cpp'].get_id() == 'clang'
-    global_args += ['-Wno-undefined-var-template', '-Wno-delete-non-abstract-non-virtual-dtor']
+    global_args += [
+        '-Wno-undefined-var-template',
+        '-Wno-delete-non-abstract-non-virtual-dtor'
+    ]
 endif
+
 if host_system == 'windows'
     if compilers['cpp'].get_id() != 'clang'
         global_args += '-masm=intel'
@@ -58,7 +86,7 @@ if get_option('build_static') == true
     endif
 endif
 
-
+# Project subdirectories
 subdir('src')
 subdir('binding-mri')
 subdir('shader')
@@ -78,7 +106,9 @@ endif
 
 exe_name = meson.project_name()
 
-executable(exe_name,
+# ModShot Build
+executable(
+    exe_name,
     sources: global_sources,
     dependencies: global_dependencies,
     include_directories: global_include_dirs,
@@ -91,8 +121,14 @@ executable(exe_name,
     install: (host_system != 'windows')
 )
 
+# ModShot Shim for Windows
 if host_system == 'windows'
-    executable(meson.project_name() + '-shim', 
-        sources: ['windows/shim.c', windows_resources]        
+    executable(
+        meson.project_name() + '-shim',
+        sources: [
+            'windows/shim.c',
+            windows_resources
+        ],
+        win_subsystem: 'windows'
     )
 endif

--- a/src/oneshot/source/oneshot.cpp
+++ b/src/oneshot/source/oneshot.cpp
@@ -16,7 +16,7 @@
 // OS-Specific code
 #if defined _WIN32
 	#define OS_W32
-	#define WIN32_LEAN_AND_MEAN
+	//#define WIN32_LEAN_AND_MEAN
 	#define SECURITY_WIN32
 	#include <windows.h>
 	#include <mmsystem.h>
@@ -483,81 +483,63 @@ bool Oneshot::msgbox(int type, const char *body, const char *title)
 {
 	if (!title)
 		title = "";
+
 #ifdef OS_LINUX
-	linux_DialogData data = {type, body, title, 0};
+	linux_DialogData data = { type, body, title, 0 };
 	gdk_threads_add_idle(linux_dialog, &data);
 	gtk_main();
 	return data.result;
 #else
+	// Buttons data
+	static const SDL_MessageBoxButtonData buttonOk = { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "OK" };
+	static const SDL_MessageBoxButtonData buttonsOk[] = { buttonOk };
+	SDL_MessageBoxButtonData buttonYes = { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, p->txtYes.c_str() };
+	SDL_MessageBoxButtonData buttonNo = { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, p->txtNo.c_str() };
+	SDL_MessageBoxButtonData buttonsYesNo[] = { buttonNo, buttonYes };
 
-	// SDL message box
-	// Button data
-	static const SDL_MessageBoxButtonData buttonOk = {SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "OK"};
-	static const SDL_MessageBoxButtonData buttonsOk[] = {buttonOk};
-	SDL_MessageBoxButtonData buttonYes = {SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, p->txtYes.c_str()};
-	SDL_MessageBoxButtonData buttonNo = {SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, p->txtNo.c_str()};
-	SDL_MessageBoxButtonData buttonsYesNo[] = {buttonNo, buttonYes};
-
-	// Messagebox data
+	// Message box data
 	SDL_MessageBoxData data;
 	data.window = NULL; //p->window;
 	data.colorScheme = 0;
 	data.title = title;
 	data.message = body;
-#ifdef OS_W32
-	LPCTSTR sound;
-#endif
 
-	//Set type
+	// Set message box type
 	switch (type)
 	{
-	case MSG_INFO:
-	case MSG_YESNO:
-	default:
-		data.flags = SDL_MESSAGEBOX_INFORMATION;
-#ifdef OS_W32
-		sound = (LPCTSTR)SND_ALIAS_SYSTEMQUESTION;
-#endif
-		break;
-	case MSG_WARN:
-		data.flags = SDL_MESSAGEBOX_WARNING;
-#ifdef OS_W32
-		sound = (LPCTSTR)SND_ALIAS_SYSTEMEXCLAMATION;
-#endif
-		break;
-	case MSG_ERR:
-		data.flags = SDL_MESSAGEBOX_WARNING;
-#ifdef OS_W32
-		sound = (LPCTSTR)SND_ALIAS_SYSTEMASTERISK;
-#endif
-		break;
+		case MSG_INFO:
+		case MSG_YESNO:
+		default:
+			data.flags = SDL_MESSAGEBOX_INFORMATION;
+			break;
+		case MSG_WARN:
+			data.flags = SDL_MESSAGEBOX_WARNING;
+			break;
+		case MSG_ERR:
+			data.flags = SDL_MESSAGEBOX_WARNING;
+			break;
 	}
 
-	// Set buttons
+	// Set message box buttons
 	switch (type)
 	{
-	case MSG_INFO:
-	case MSG_WARN:
-	case MSG_ERR:
-	default:
-		data.numbuttons = 1;
-		data.buttons = buttonsOk;
-		break;
-	case MSG_YESNO:
-		data.numbuttons = 2;
-		data.buttons = buttonsYesNo;
-		break;
+		case MSG_INFO:
+		case MSG_WARN:
+		case MSG_ERR:
+		default:
+			data.numbuttons = 1;
+			data.buttons = buttonsOk;
+			break;
+		case MSG_YESNO:
+			data.numbuttons = 2;
+			data.buttons = buttonsYesNo;
+			break;
 	}
 
-	// Show messagebox
-#ifdef OS_W32
-	PlaySound(sound, NULL, SND_ALIAS_ID | SND_ASYNC);
-#endif
+	// Show message box
 	int button;
-
 	#ifdef OS_OSX
 		int *btn = &button;
-
 		// Message boxes and UI changes must be performed from the main thread on macOS Mojave and above.
 		// This block ensures the message box will show from the main thread.
 		dispatch_sync(dispatch_get_main_queue(),
@@ -568,7 +550,7 @@ bool Oneshot::msgbox(int type, const char *body, const char *title)
 	#endif
 
 	return button ? true : false;
-#endif // #ifdef OS_LINUX
+#endif
 }
 
 std::string Oneshot::textinput(const char* prompt, int char_limit, const char* fontName) {

--- a/src/oneshot/source/oneshot.cpp
+++ b/src/oneshot/source/oneshot.cpp
@@ -481,8 +481,12 @@ void Oneshot::setAllowExit(bool allowExit)
 
 bool Oneshot::msgbox(int type, const char *body, const char *title)
 {
-	if (!title)
+	if (title && !title[0])
+#ifdef _WIN32
+		title = "\u200b"; // Zero width space instead of filename in messagebox title
+#else
 		title = "";
+#endif
 
 #ifdef OS_LINUX
 	linux_DialogData data = { type, body, title, 0 };

--- a/windows/install.sh
+++ b/windows/install.sh
@@ -15,7 +15,7 @@ function fail() {
 }
 
 function copy_dependencies() {
-    if [[ ${2@L} = /c/windows/system32/* ]]; then
+    if [[ ${2@L} = /c/windows/* ]]; then
         return
     fi
     if [[ -f "$DESTDIR/$1" ]]; then

--- a/windows/manifest.xml
+++ b/windows/manifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity
+        type="win32"
+        name="ModShot"
+        processorArchitecture="AMD64"
+        version="1.0.0.0"
+    />
+    <description>ModShot - A modified mkxp-oneshot for OneShot mods</description>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                language="*"
+                processorArchitecture="AMD64"
+                version="6.0.0.0"
+                publicKeyToken="6595b64144ccf1df"
+            />
+        </dependentAssembly>
+    </dependency>
+</assembly>

--- a/windows/manifest.xml
+++ b/windows/manifest.xml
@@ -7,6 +7,31 @@
         version="1.0.0.0"
     />
     <description>ModShot - A modified mkxp-oneshot for OneShot mods</description>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- The IDs below indicates application support for each Windows version -->
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
     <dependency>
         <dependentAssembly>
             <assemblyIdentity

--- a/windows/manifest.xml
+++ b/windows/manifest.xml
@@ -3,7 +3,7 @@
     <assemblyIdentity
         type="win32"
         name="ModShot"
-        processorArchitecture="AMD64"
+        processorArchitecture="*"
         version="1.0.0.0"
     />
     <description>ModShot - A modified mkxp-oneshot for OneShot mods</description>
@@ -38,7 +38,7 @@
                 type="win32"
                 name="Microsoft.Windows.Common-Controls"
                 language="*"
-                processorArchitecture="AMD64"
+                processorArchitecture="*"
                 version="6.0.0.0"
                 publicKeyToken="6595b64144ccf1df"
             />

--- a/windows/meson.build
+++ b/windows/meson.build
@@ -1,9 +1,9 @@
 win = import('windows')
 
 res = files(
-'resource.h',
-'icon.ico',
-'resource.rc'
+    'resource.h',
+    'icon.ico',
+    'manifest.xml'
 )
 
 windows_resources = win.compile_resources('resource.rc', depend_files: res)

--- a/windows/resource.rc
+++ b/windows/resource.rc
@@ -1,7 +1,10 @@
-#include <windows.h>
+#include <winuser.h>
+
 #include "resource.h"
 
 IDI_APPICON ICON "icon.ico"
+
+1 RT_MANIFEST "manifest.xml"
 
 IDR_APPVERINFO VERSIONINFO
 FILEVERSION 1, 0, 0, 0


### PR DESCRIPTION
- Add Win32 application manifest to ModShot and ModShot shim executables
- Add linker args (`--(major/minor)-subsystem-version`, `--(major/minor)-os-version`) for setting Windows subversion and OS version to 6.00 (Windows Vista/7)
- Fixed messagebox title due to duplicate strings